### PR TITLE
Implement /random command

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -16,7 +16,9 @@
       "Bash(npm install:*)",
       "Bash(npm run lint)",
       "Bash(findstr:*)",
-      "Bash(cat:*)"
+      "Bash(cat:*)",
+      "Bash(gh issue create:*)",
+      "Bash(gh issue view:*)"
     ]
   }
 }

--- a/src/_handlers/commands/global/random.ts
+++ b/src/_handlers/commands/global/random.ts
@@ -1,0 +1,29 @@
+import { questionService } from '../../../services';
+import { BotCommandInteraction } from '../../../structures';
+import { QuestionType } from '../../../types';
+import { Command } from '../../../utils';
+import { questionEmbed } from '../../../views';
+
+const random = new Command('random', 'Get a random truth or dare question')
+  .setNSFW(true)
+  .setAdministrator(false)
+  .setExecute(async (interaction: BotCommandInteraction): Promise<void> => {
+    await interaction.deferReply();
+
+    // 50/50 random selection
+    const selectedType = Math.random() < 0.5 ? QuestionType.Truth : QuestionType.Dare;
+
+    const question = await questionService.getRandomQuestion(selectedType);
+
+    if (!question) {
+      await interaction.editReply({
+        content: `❌ No approved ${selectedType} questions available. Try again later!`,
+      });
+      return;
+    }
+
+    const message = questionEmbed(question);
+    await interaction.sendReply(null, message);
+  });
+
+export default random;

--- a/src/_handlers/commands/tests/global/random.test.ts
+++ b/src/_handlers/commands/tests/global/random.test.ts
@@ -1,0 +1,171 @@
+import { ChatInputCommandInteraction } from 'discord.js';
+import { questionService } from '../../../../services';
+import { BotCommandInteraction } from '../../../../structures';
+import { QuestionType } from '../../../../types';
+import { questionEmbed } from '../../../../views';
+import random from '../../global/random';
+
+// Mock services and views
+jest.mock('../../../../services', () => ({
+  questionService: {
+    getRandomQuestion: jest.fn(),
+  },
+}));
+
+jest.mock('../../../../views', () => ({
+  questionEmbed: jest.fn(),
+}));
+
+describe('random command', () => {
+  let mockInteraction: any;
+  let botInteraction: BotCommandInteraction;
+  let mathRandomSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockInteraction = {
+      reply: jest.fn().mockResolvedValue(undefined),
+      editReply: jest.fn().mockResolvedValue(undefined),
+      deferReply: jest.fn().mockResolvedValue(undefined),
+      user: { id: '123456789' },
+      guildId: '987654321',
+      channelId: '111222333',
+      options: {
+        getString: jest.fn(),
+      },
+    };
+
+    botInteraction = new BotCommandInteraction(
+      mockInteraction as ChatInputCommandInteraction,
+      'test-execution-id'
+    );
+
+    // Create spy for Math.random
+    mathRandomSpy = jest.spyOn(Math, 'random');
+  });
+
+  afterEach(() => {
+    mathRandomSpy.mockRestore();
+  });
+
+  it('should send a random truth question when Math.random < 0.5', async () => {
+    const mockQuestion = {
+      id: 1,
+      type: QuestionType.Truth,
+      question: 'What is your biggest secret?',
+      user_id: '999888777',
+      is_approved: true,
+      approved_by: '111222333',
+      datetime_approved: new Date(),
+      is_banned: false,
+      ban_reason: null,
+      banned_by: null,
+      datetime_banned: null,
+      created: new Date(),
+      server_id: '987654321',
+      message_id: null,
+      is_deleted: false,
+      datetime_deleted: null,
+    };
+
+    const mockEmbedMessage = {
+      content: { type: 'container', children: [] },
+      components: [],
+    };
+
+    // Mock Math.random to return value < 0.5 (should select Truth)
+    mathRandomSpy.mockReturnValue(0.3);
+
+    (questionService.getRandomQuestion as jest.Mock).mockResolvedValue(mockQuestion);
+    (questionEmbed as jest.Mock).mockReturnValue(mockEmbedMessage);
+
+    // Mock sendReply method
+    botInteraction.sendReply = jest.fn().mockResolvedValue(undefined);
+
+    await random.execute(botInteraction);
+
+    expect(mockInteraction.deferReply).toHaveBeenCalled();
+    expect(questionService.getRandomQuestion).toHaveBeenCalledWith(QuestionType.Truth);
+    expect(questionEmbed).toHaveBeenCalledWith(mockQuestion);
+    expect(botInteraction.sendReply).toHaveBeenCalledWith(null, mockEmbedMessage);
+  });
+
+  it('should send a random dare question when Math.random >= 0.5', async () => {
+    const mockQuestion = {
+      id: 2,
+      type: QuestionType.Dare,
+      question: 'Do 10 pushups',
+      user_id: '999888777',
+      is_approved: true,
+      approved_by: '111222333',
+      datetime_approved: new Date(),
+      is_banned: false,
+      ban_reason: null,
+      banned_by: null,
+      datetime_banned: null,
+      created: new Date(),
+      server_id: '987654321',
+      message_id: null,
+      is_deleted: false,
+      datetime_deleted: null,
+    };
+
+    const mockEmbedMessage = {
+      content: { type: 'container', children: [] },
+      components: [],
+    };
+
+    // Mock Math.random to return value >= 0.5 (should select Dare)
+    mathRandomSpy.mockReturnValue(0.7);
+
+    (questionService.getRandomQuestion as jest.Mock).mockResolvedValue(mockQuestion);
+    (questionEmbed as jest.Mock).mockReturnValue(mockEmbedMessage);
+
+    // Mock sendReply method
+    botInteraction.sendReply = jest.fn().mockResolvedValue(undefined);
+
+    await random.execute(botInteraction);
+
+    expect(mockInteraction.deferReply).toHaveBeenCalled();
+    expect(questionService.getRandomQuestion).toHaveBeenCalledWith(QuestionType.Dare);
+    expect(questionEmbed).toHaveBeenCalledWith(mockQuestion);
+    expect(botInteraction.sendReply).toHaveBeenCalledWith(null, mockEmbedMessage);
+  });
+
+  it('should handle no approved truth questions available', async () => {
+    // Mock Math.random to select Truth
+    mathRandomSpy.mockReturnValue(0.3);
+
+    (questionService.getRandomQuestion as jest.Mock).mockResolvedValue(null);
+
+    await random.execute(botInteraction);
+
+    expect(mockInteraction.deferReply).toHaveBeenCalled();
+    expect(questionService.getRandomQuestion).toHaveBeenCalledWith(QuestionType.Truth);
+    expect(mockInteraction.editReply).toHaveBeenCalledWith({
+      content: '❌ No approved truth questions available. Try again later!',
+    });
+  });
+
+  it('should handle no approved dare questions available', async () => {
+    // Mock Math.random to select Dare
+    mathRandomSpy.mockReturnValue(0.7);
+
+    (questionService.getRandomQuestion as jest.Mock).mockResolvedValue(null);
+
+    await random.execute(botInteraction);
+
+    expect(mockInteraction.deferReply).toHaveBeenCalled();
+    expect(questionService.getRandomQuestion).toHaveBeenCalledWith(QuestionType.Dare);
+    expect(mockInteraction.editReply).toHaveBeenCalledWith({
+      content: '❌ No approved dare questions available. Try again later!',
+    });
+  });
+
+  it('should have correct command properties', () => {
+    expect(random.name).toBe('random');
+    expect(random.isNSFW).toBe(true);
+    expect(random.isAdministrator).toBe(false);
+  });
+});


### PR DESCRIPTION
Implements the `/random` command that randomly picks between truth or dare questions.

## Changes
- ✅ Created `src/_handlers/commands/global/random.ts`
- ✅ Randomly selects truth or dare (50/50 chance via Math.random)
- ✅ Calls `questionService.getRandomQuestion()` with selected type
- ✅ Uses `questionEmbed` view to build response
- ✅ Handles errors gracefully (no questions available)
- ✅ Comprehensive unit tests (5 test cases)

## Implementation Details
The command:
- Uses existing infrastructure (QuestionService, questionEmbed)
- NSFW-marked (same as /truth and /dare)
- Auto-registers via bot's directory scanning
- Shows question type in embed (no additional label needed)

## Test Coverage
- Random truth selection when Math.random < 0.5
- Random dare selection when Math.random >= 0.5
- No truth questions available
- No dare questions available
- Command properties validation

## Testing
```bash
# Run tests
npm test -- src/_handlers/commands/tests/global/random.test.ts

# Run lint
npm run lint
```

**Results:** ✅ All 5 tests passing, 0 lint errors

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)