### PR TITLE
#126 - Update all string based messages to new Components V2 views

### DIFF
--- a/.github/workflows/bot-service-lint.yml
+++ b/.github/workflows/bot-service-lint.yml
@@ -26,6 +26,9 @@ permissions:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: bot-service
 
     steps:
       - name: Checkout code
@@ -36,6 +39,7 @@ jobs:
         with:
           node-version: '22'
           cache: 'npm'
+          cache-dependency-path: 'bot-service/package-lock.json'
 
       - name: Configure npm for private packages
         run: npm config set //npm.pkg.github.com/:_authToken ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/bot-service-test-buttons.yml
+++ b/.github/workflows/bot-service-test-buttons.yml
@@ -22,6 +22,9 @@ permissions:
 jobs:
   test-buttons:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: bot-service
 
     steps:
       - name: Checkout code
@@ -32,6 +35,7 @@ jobs:
         with:
           node-version: '22'
           cache: 'npm'
+          cache-dependency-path: 'bot-service/package-lock.json'
 
       - name: Configure npm for private packages
         run: npm config set //npm.pkg.github.com/:_authToken ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/bot-service-test-commands.yml
+++ b/.github/workflows/bot-service-test-commands.yml
@@ -22,6 +22,9 @@ permissions:
 jobs:
   test-commands:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: bot-service
 
     steps:
       - name: Checkout code
@@ -32,6 +35,7 @@ jobs:
         with:
           node-version: '22'
           cache: 'npm'
+          cache-dependency-path: 'bot-service/package-lock.json'
 
       - name: Configure npm for private packages
         run: npm config set //npm.pkg.github.com/:_authToken ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/bot-service-test-core.yml
+++ b/.github/workflows/bot-service-test-core.yml
@@ -30,6 +30,9 @@ permissions:
 jobs:
   test-core:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: bot-service
 
     steps:
       - name: Checkout code
@@ -40,6 +43,7 @@ jobs:
         with:
           node-version: '22'
           cache: 'npm'
+          cache-dependency-path: 'bot-service/package-lock.json'
 
       - name: Configure npm for private packages
         run: npm config set //npm.pkg.github.com/:_authToken ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/bot-service-test-events.yml
+++ b/.github/workflows/bot-service-test-events.yml
@@ -22,6 +22,9 @@ permissions:
 jobs:
   test-events:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: bot-service
 
     steps:
       - name: Checkout code
@@ -32,6 +35,7 @@ jobs:
         with:
           node-version: '22'
           cache: 'npm'
+          cache-dependency-path: 'bot-service/package-lock.json'
 
       - name: Configure npm for private packages
         run: npm config set //npm.pkg.github.com/:_authToken ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/bot-service-test-models.yml
+++ b/.github/workflows/bot-service-test-models.yml
@@ -20,6 +20,9 @@ permissions:
 jobs:
   test-models:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: bot-service
 
     steps:
       - name: Checkout code
@@ -30,6 +33,7 @@ jobs:
         with:
           node-version: '22'
           cache: 'npm'
+          cache-dependency-path: 'bot-service/package-lock.json'
 
       - name: Configure npm for private packages
         run: npm config set //npm.pkg.github.com/:_authToken ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/bot-service-test-selectMenus.yml
+++ b/.github/workflows/bot-service-test-selectMenus.yml
@@ -22,6 +22,9 @@ permissions:
 jobs:
   test-selectMenus:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: bot-service
 
     steps:
       - name: Checkout code
@@ -32,6 +35,7 @@ jobs:
         with:
           node-version: '22'
           cache: 'npm'
+          cache-dependency-path: 'bot-service/package-lock.json'
 
       - name: Configure npm for private packages
         run: npm config set //npm.pkg.github.com/:_authToken ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/bot-service-test-services.yml
+++ b/.github/workflows/bot-service-test-services.yml
@@ -22,6 +22,9 @@ permissions:
 jobs:
   test-services:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: bot-service
 
     steps:
       - name: Checkout code
@@ -32,6 +35,7 @@ jobs:
         with:
           node-version: '22'
           cache: 'npm'
+          cache-dependency-path: 'bot-service/package-lock.json'
 
       - name: Configure npm for private packages
         run: npm config set //npm.pkg.github.com/:_authToken ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/bot-service-test-utils.yml
+++ b/.github/workflows/bot-service-test-utils.yml
@@ -20,6 +20,9 @@ permissions:
 jobs:
   test-utils:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: bot-service
 
     steps:
       - name: Checkout code
@@ -30,6 +33,7 @@ jobs:
         with:
           node-version: '22'
           cache: 'npm'
+          cache-dependency-path: 'bot-service/package-lock.json'
 
       - name: Configure npm for private packages
         run: npm config set //npm.pkg.github.com/:_authToken ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/bot-service-test-views.yml
+++ b/.github/workflows/bot-service-test-views.yml
@@ -20,6 +20,9 @@ permissions:
 jobs:
   test-views:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: bot-service
 
     steps:
       - name: Checkout code
@@ -30,6 +33,7 @@ jobs:
         with:
           node-version: '22'
           cache: 'npm'
+          cache-dependency-path: 'bot-service/package-lock.json'
 
       - name: Configure npm for private packages
         run: npm config set //npm.pkg.github.com/:_authToken ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/bot-service-test-webhook.yml
+++ b/.github/workflows/bot-service-test-webhook.yml
@@ -20,6 +20,9 @@ permissions:
 jobs:
   test-webhook:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: bot-service
 
     steps:
       - name: Checkout code
@@ -30,6 +33,7 @@ jobs:
         with:
           node-version: '22'
           cache: 'npm'
+          cache-dependency-path: 'bot-service/package-lock.json'
 
       - name: Configure npm for private packages
         run: npm config set //npm.pkg.github.com/:_authToken ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/database-service-test-database.yml
+++ b/.github/workflows/database-service-test-database.yml
@@ -21,6 +21,9 @@ jobs:
   fresh-install:
     name: Fresh Install Test
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: database-service
 
     services:
       postgres:
@@ -46,6 +49,7 @@ jobs:
         with:
           node-version: '22'
           cache: 'npm'
+          cache-dependency-path: 'database-service/package-lock.json'
 
       - name: Configure npm for private packages
         run: npm config set //npm.pkg.github.com/:_authToken ${{ secrets.GITHUB_TOKEN }}
@@ -68,6 +72,9 @@ jobs:
   migration-test:
     name: Migration Rollout/Rollback Test
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: database-service
 
     services:
       postgres:
@@ -95,6 +102,7 @@ jobs:
         with:
           node-version: '22'
           cache: 'npm'
+          cache-dependency-path: 'database-service/package-lock.json'
 
       - name: Configure npm for private packages
         run: npm config set //npm.pkg.github.com/:_authToken ${{ secrets.GITHUB_TOKEN }}
@@ -170,6 +178,9 @@ jobs:
   schema-sync:
     name: Schema Sync Validation
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: database-service
 
     services:
       postgres-migrated:
@@ -211,6 +222,7 @@ jobs:
         with:
           node-version: '22'
           cache: 'npm'
+          cache-dependency-path: 'database-service/package-lock.json'
 
       - name: Configure npm for private packages
         run: npm config set //npm.pkg.github.com/:_authToken ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/moderator-service-test-middleware.yml
+++ b/.github/workflows/moderator-service-test-middleware.yml
@@ -22,6 +22,9 @@ permissions:
 jobs:
   test-middleware:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: moderator-service
 
     steps:
       - name: Checkout code
@@ -32,6 +35,7 @@ jobs:
         with:
           node-version: '22'
           cache: 'npm'
+          cache-dependency-path: 'moderator-service/package-lock.json'
 
       - name: Configure npm for private packages
         run: npm config set //npm.pkg.github.com/:_authToken ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/moderator-service-test-routes.yml
+++ b/.github/workflows/moderator-service-test-routes.yml
@@ -22,6 +22,9 @@ permissions:
 jobs:
   test-routes:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: moderator-service
 
     steps:
       - name: Checkout code
@@ -32,6 +35,7 @@ jobs:
         with:
           node-version: '22'
           cache: 'npm'
+          cache-dependency-path: 'moderator-service/package-lock.json'
 
       - name: Configure npm for private packages
         run: npm config set //npm.pkg.github.com/:_authToken ${{ secrets.GITHUB_TOKEN }}

--- a/bot-service/package-lock.json
+++ b/bot-service/package-lock.json
@@ -8,7 +8,7 @@
       "name": "truth-or-dare-bot",
       "version": "1.0.0",
       "dependencies": {
-        "@vulps22/bot-interactions": "^1.0.4",
+        "@vulps22/bot-interactions": "^1.1.0",
         "@vulps22/dynamic-endpoint-router": "^1.0.1",
         "@vulps22/logger": "^1.0.0",
         "@vulps22/project-encourage-types": "^1.0.0",
@@ -2396,9 +2396,9 @@
       }
     },
     "node_modules/@vulps22/bot-interactions": {
-      "version": "1.0.4",
-      "resolved": "https://npm.pkg.github.com/download/@vulps22/bot-interactions/1.0.4/0b86da9884929ef0131732c67db95e56ece0fd2d",
-      "integrity": "sha512-/IfzULkr5MQc9Ck6/APo1kFFTJWOno0znK+xcVpbErr7aQyIcyqhpX34Mvfn4T4Vff10sILlpYWzS1DiKPPYMQ==",
+      "version": "1.1.0",
+      "resolved": "https://npm.pkg.github.com/download/@vulps22/bot-interactions/1.1.0/d388ab741541157c6490098720165ce42b79a71e",
+      "integrity": "sha512-/Qb3zjpdRh4jq9NTcTGILQg0X9VzxkKdQket3RaF/GibgGhMJFzrtndi0kjq20YFb75Y2RAu/Yxm7PTAhldktw==",
       "dependencies": {
         "@vulps22/logger": "^1.0.0",
         "discord.js": "^14.16.3"

--- a/bot-service/package.json
+++ b/bot-service/package.json
@@ -37,7 +37,7 @@
     "node": ">=20.6.0"
   },
   "dependencies": {
-    "@vulps22/bot-interactions": "^1.0.4",
+    "@vulps22/bot-interactions": "^1.1.0",
     "@vulps22/dynamic-endpoint-router": "^1.0.1",
     "@vulps22/logger": "^1.0.0",
     "@vulps22/project-encourage-types": "^1.0.0",

--- a/bot-service/src/_handlers/buttons/question/done.ts
+++ b/bot-service/src/_handlers/buttons/question/done.ts
@@ -1,4 +1,4 @@
-import { BotButtonInteraction } from '@vulps22/bot-interactions';
+import { BotButtonInteraction, errorView } from '@vulps22/bot-interactions';
 import { Handler } from '../../../utils';
 import { Logger } from '@vulps22/logger';
 import { DSError } from '../../../client';
@@ -20,7 +20,7 @@ const done: Handler<BotButtonInteraction> = {
 
             challenge = await challengeService.getChallengeByMessageId(messageId);
             if (!challenge) {
-                await interaction.ephemeralFollowUp('❌ Could not find tracking data for this challenge.');
+                await interaction.ephemeralFollowUp(errorView('Could not find tracking data for this challenge.'));
                 return;
             }
 
@@ -28,7 +28,7 @@ const done: Handler<BotButtonInteraction> = {
 
             const challengeVote = await votingService.getVoteCount(challengeId);
             if (challengeVote.final_result !== null) {
-                await interaction.ephemeralFollowUp('❌ This challenge has already been locked.');
+                await interaction.ephemeralFollowUp(errorView('This challenge has already been locked.'));
                 return;
             }
 
@@ -36,7 +36,7 @@ const done: Handler<BotButtonInteraction> = {
                 updated = await votingService.vote(challengeId, userId, 'done');
             } catch (error) {
                 if (error instanceof DSError && error.status === 409) {
-                    await interaction.ephemeralFollowUp('❌ You have already voted on this question.');
+                    await interaction.ephemeralFollowUp(errorView('You have already voted on this question.'));
                     return;
                 }
                 throw error;
@@ -49,7 +49,7 @@ const done: Handler<BotButtonInteraction> = {
 
             question = await questionService.getQuestionById(challenge.question_id);
             if (question) {
-                await interaction.updateComponentMessage(null, challengeEmbed(question, challenge, updated));
+                await interaction.updateComponentMessage(challengeEmbed(question, challenge, updated));
             }
         } catch (error) {
             console.error('[done] raw error:', error);
@@ -57,7 +57,7 @@ const done: Handler<BotButtonInteraction> = {
             console.error('[done] challenge:', challenge ?? 'undefined');
             console.error('[done] updated:', updated ?? 'undefined');
             Logger.error(`Done handler error for message ${messageId}: ${error instanceof Error ? error.message : String(error)}`);
-            await interaction.ephemeralFollowUp('❌ Something went wrong. Please try again.');
+            await interaction.ephemeralFollowUp(errorView('Something went wrong. Please try again.'));
         }
     }
 };

--- a/bot-service/src/_handlers/buttons/question/failed.ts
+++ b/bot-service/src/_handlers/buttons/question/failed.ts
@@ -1,4 +1,4 @@
-import { BotButtonInteraction } from '@vulps22/bot-interactions';
+import { BotButtonInteraction, errorView } from '@vulps22/bot-interactions';
 import { Handler } from '../../../utils';
 import { Logger } from '@vulps22/logger';
 import { DSError } from '../../../client';
@@ -16,7 +16,7 @@ const failed: Handler<BotButtonInteraction> = {
 
             const challenge = await challengeService.getChallengeByMessageId(messageId);
             if (!challenge) {
-                await interaction.ephemeralFollowUp('❌ Could not find tracking data for this challenge.');
+                await interaction.ephemeralFollowUp(errorView('Could not find tracking data for this challenge.'));
                 return;
             }
 
@@ -24,7 +24,7 @@ const failed: Handler<BotButtonInteraction> = {
 
             const challengeVote = await votingService.getVoteCount(challengeId);
             if (challengeVote.final_result !== null) {
-                await interaction.ephemeralFollowUp('❌ This challenge has already been locked.');
+                await interaction.ephemeralFollowUp(errorView('This challenge has already been locked.'));
                 return;
             }
 
@@ -33,7 +33,7 @@ const failed: Handler<BotButtonInteraction> = {
                 updated = await votingService.vote(challengeId, userId, 'failed');
             } catch (error) {
                 if (error instanceof DSError && error.status === 409) {
-                    await interaction.ephemeralFollowUp('❌ You have already voted on this question.');
+                    await interaction.ephemeralFollowUp(errorView('You have already voted on this question.'));
                     return;
                 }
                 throw error;
@@ -46,11 +46,11 @@ const failed: Handler<BotButtonInteraction> = {
 
             const question = await questionService.getQuestionById(challenge.question_id);
             if (question) {
-                await interaction.updateComponentMessage(null, challengeEmbed(question, challenge, updated));
+                await interaction.updateComponentMessage(challengeEmbed(question, challenge, updated));
             }
         } catch (error) {
             Logger.error(`Failed handler error for message ${messageId}: ${error instanceof Error ? error.message : String(error)}`);
-            await interaction.ephemeralFollowUp('❌ Something went wrong. Please try again.');
+            await interaction.ephemeralFollowUp(errorView('Something went wrong. Please try again.'));
         }
     }
 };

--- a/bot-service/src/_handlers/buttons/question/report.ts
+++ b/bot-service/src/_handlers/buttons/question/report.ts
@@ -1,5 +1,5 @@
 import { ActionRowBuilder, ModalBuilder, TextInputBuilder, TextInputStyle } from 'discord.js';
-import { BotButtonInteraction } from '@vulps22/bot-interactions';
+import { BotButtonInteraction, errorView } from '@vulps22/bot-interactions';
 import { Handler } from '../../../utils';
 
 const reportButton: Handler<BotButtonInteraction> = {
@@ -8,7 +8,7 @@ const reportButton: Handler<BotButtonInteraction> = {
     async execute(interaction: BotButtonInteraction): Promise<void> {
         const questionId = interaction.params.get(reportButton.params!.id);
         if (!questionId) {
-            await interaction.ephemeralReply('❌ Invalid question ID');
+            await interaction.ephemeralReply(errorView('Invalid question ID'));
             throw new Error('Invalid question ID when using Button: question_report');
         }
 

--- a/bot-service/src/_handlers/buttons/question/skip.ts
+++ b/bot-service/src/_handlers/buttons/question/skip.ts
@@ -1,4 +1,4 @@
-import { BotButtonInteraction } from '@vulps22/bot-interactions';
+import { BotButtonInteraction, errorView } from '@vulps22/bot-interactions';
 import { Handler } from '../../../utils';
 import { Logger } from '@vulps22/logger';
 import { challengeService, inventoryService, questionService, votingService } from '../../../services';
@@ -16,12 +16,12 @@ const skip: Handler<BotButtonInteraction> = {
 
             const challenge = await challengeService.getChallengeByMessageId(messageId);
             if (!challenge) {
-                await interaction.ephemeralFollowUp('❌ Could not find tracking data for this challenge.');
+                await interaction.ephemeralFollowUp(errorView('Could not find tracking data for this challenge.'));
                 return;
             }
 
             if (challenge.user_id !== userId) {
-                await interaction.ephemeralFollowUp('❌ Only the challenge recipient can skip.');
+                await interaction.ephemeralFollowUp(errorView('Only the challenge recipient can skip.'));
                 return;
             }
 
@@ -29,12 +29,12 @@ const skip: Handler<BotButtonInteraction> = {
 
             const challengeVote = await votingService.getVoteCount(challengeId);
             if (challengeVote.final_result !== null) {
-                await interaction.ephemeralFollowUp('❌ This challenge has already been locked.');
+                await interaction.ephemeralFollowUp(errorView('This challenge has already been locked.'));
                 return;
             }
             const skips = await inventoryService.consume(userId, 'skip', 1);
             if(!skips) {
-                await interaction.ephemeralFollowUp(`❌ You have no skips left! You can earn more by voting at [Top.gg](<${process.env.TOPGG_URL}>).`);
+                await interaction.ephemeralFollowUp(errorView(`You have no skips left! You can earn more by voting at [Top.gg](<${process.env.TOPGG_URL}>).`));
                 return;
             }
 
@@ -43,11 +43,11 @@ const skip: Handler<BotButtonInteraction> = {
 
             const question = await questionService.getQuestionById(challenge.question_id);
             if (question) {
-                await interaction.updateComponentMessage(null, challengeEmbed(question, challenge, updated));
+                await interaction.updateComponentMessage(challengeEmbed(question, challenge, updated));
             }
         } catch (error) {
             Logger.error(`Skip handler error for message ${messageId}: ${error instanceof Error ? error.message : String(error)}`);
-            await interaction.ephemeralFollowUp('❌ Something went wrong. Please try again.');
+            await interaction.ephemeralFollowUp(errorView('Something went wrong. Please try again.'));
         }
     }
 };

--- a/bot-service/src/_handlers/buttons/setup/acceptRules.ts
+++ b/bot-service/src/_handlers/buttons/setup/acceptRules.ts
@@ -1,6 +1,6 @@
 import { PermissionFlagsBits } from 'discord.js';
 import { serverService } from '../../../services';
-import { BotButtonInteraction } from '@vulps22/bot-interactions';
+import { BotButtonInteraction, errorView } from '@vulps22/bot-interactions';
 import { Handler } from '../../../utils';
 import { channelSelectView } from '../../../views';
 
@@ -11,32 +11,32 @@ const acceptRulesButton: Handler<BotButtonInteraction> = {
         // Verify user is admin
         const member = interaction.member;
         if (!member || !('permissions' in member)) {
-            await interaction.ephemeralReply('❌ Only administrators can accept rules for this server.');
+            await interaction.ephemeralReply(errorView('Only administrators can accept rules for this server.'));
             return;
         }
 
         const permissions = member.permissions;
         if (typeof permissions === 'string') {
-            await interaction.ephemeralReply('❌ Only administrators can accept rules for this server.');
+            await interaction.ephemeralReply(errorView('Only administrators can accept rules for this server.'));
             return;
         }
 
         if (!permissions.has(PermissionFlagsBits.Administrator) &&
             !permissions.has(PermissionFlagsBits.ManageGuild)) {
-            await interaction.ephemeralReply('❌ Only administrators can accept rules for this server.');
+            await interaction.ephemeralReply(errorView('Only administrators can accept rules for this server.'));
             return;
         }
 
         const guildId = interaction.guildId;
         if (!guildId) {
-            await interaction.ephemeralReply('❌ This can only be used in a server.');
+            await interaction.ephemeralReply(errorView('This can only be used in a server.'));
             return;
         }
 
         // Block if server is banned
         const banReason = await serverService.isServerBanned(guildId);
         if (banReason) {
-            await interaction.ephemeralReply(`❌ This server is banned from using the bot. Reason: ${banReason}`);
+            await interaction.ephemeralReply(errorView(`This server is banned from using the bot. Reason: ${banReason}`));
             return;
         }
 
@@ -45,7 +45,7 @@ const acceptRulesButton: Handler<BotButtonInteraction> = {
 
         // Proceed to channel selection step
         const message = channelSelectView();
-        await interaction.sendReply(null, message);
+        await interaction.sendReply(message);
     }
 };
 

--- a/bot-service/src/_handlers/buttons/setup/acceptTerms.ts
+++ b/bot-service/src/_handlers/buttons/setup/acceptTerms.ts
@@ -1,6 +1,6 @@
 import { PermissionFlagsBits } from 'discord.js';
 import { serverService } from '../../../services';
-import { BotButtonInteraction } from '@vulps22/bot-interactions';
+import { BotButtonInteraction, errorView } from '@vulps22/bot-interactions';
 import { Handler } from '../../../utils';
 import { rulesView } from '../../../views';
 
@@ -11,20 +11,20 @@ const acceptTermsButton: Handler<BotButtonInteraction> = {
         // Verify user is admin
         const member = interaction.member;
         if (!member || !('permissions' in member)) {
-            await interaction.ephemeralReply('❌ Only administrators can accept terms for this server.');
+            await interaction.ephemeralReply(errorView('Only administrators can accept terms for this server.'));
             return;
         }
 
         const permissions = member.permissions as import('discord.js').PermissionsBitField;
         if (!permissions.has(PermissionFlagsBits.Administrator) &&
             !permissions.has(PermissionFlagsBits.ManageGuild)) {
-            await interaction.ephemeralReply('❌ Only administrators can accept terms for this server.');
+            await interaction.ephemeralReply(errorView('Only administrators can accept terms for this server.'));
             return;
         }
 
         const guildId = interaction.guildId;
         if (!guildId) {
-            await interaction.ephemeralReply('❌ This can only be used in a server.');
+            await interaction.ephemeralReply(errorView('This can only be used in a server.'));
             return;
         }
 
@@ -33,7 +33,7 @@ const acceptTermsButton: Handler<BotButtonInteraction> = {
 
         // Proceed to rules step
         const message = rulesView();
-        await interaction.sendReply(null, message);
+        await interaction.sendReply(message);
     }
 };
 

--- a/bot-service/src/_handlers/buttons/setup/declineRules.ts
+++ b/bot-service/src/_handlers/buttons/setup/declineRules.ts
@@ -1,5 +1,5 @@
 import { PermissionFlagsBits } from 'discord.js';
-import { BotButtonInteraction } from '@vulps22/bot-interactions';
+import { BotButtonInteraction, errorView } from '@vulps22/bot-interactions';
 import { Handler } from '../../../utils';
 import { channelSelectView } from '../../../views';
 
@@ -10,25 +10,25 @@ const declineRulesButton: Handler<BotButtonInteraction> = {
         // Verify user is admin
         const member = interaction.member;
         if (!member || !('permissions' in member)) {
-            await interaction.ephemeralReply('❌ Only administrators can decline rules for this server.');
+            await interaction.ephemeralReply(errorView('Only administrators can decline rules for this server.'));
             return;
         }
 
         const permissions = member.permissions;
         if (typeof permissions === 'string') {
-            await interaction.ephemeralReply('❌ Only administrators can decline rules for this server.');
+            await interaction.ephemeralReply(errorView('Only administrators can decline rules for this server.'));
             return;
         }
 
         if (!permissions.has(PermissionFlagsBits.Administrator) &&
             !permissions.has(PermissionFlagsBits.ManageGuild)) {
-            await interaction.ephemeralReply('❌ Only administrators can decline rules for this server.');
+            await interaction.ephemeralReply(errorView('Only administrators can decline rules for this server.'));
             return;
         }
 
         const guildId = interaction.guildId;
         if (!guildId) {
-            await interaction.ephemeralReply('❌ This can only be used in a server.');
+            await interaction.ephemeralReply(errorView('This can only be used in a server.'));
             return;
         }
 
@@ -37,7 +37,7 @@ const declineRulesButton: Handler<BotButtonInteraction> = {
 
         // Proceed to channel selection step anyway
         const message = channelSelectView();
-        await interaction.sendReply(null, message);
+        await interaction.sendReply(message);
     }
 };
 

--- a/bot-service/src/_handlers/buttons/setup/declineTerms.ts
+++ b/bot-service/src/_handlers/buttons/setup/declineTerms.ts
@@ -1,5 +1,5 @@
 import { PermissionFlagsBits } from 'discord.js';
-import { BotButtonInteraction } from '@vulps22/bot-interactions';
+import { BotButtonInteraction, errorView, noticeView } from '@vulps22/bot-interactions';
 import { Handler } from '../../../utils';
 
 const declineTermsButton: Handler<BotButtonInteraction> = {
@@ -9,26 +9,26 @@ const declineTermsButton: Handler<BotButtonInteraction> = {
         // Verify user is admin
         const member = interaction.member;
         if (!member || !('permissions' in member)) {
-            await interaction.ephemeralReply('❌ Only administrators can decline terms for this server.');
+            await interaction.ephemeralReply(errorView('Only administrators can decline terms for this server.'));
             return;
         }
 
         const permissions = member.permissions as import('discord.js').PermissionsBitField;
         if (!permissions.has(PermissionFlagsBits.Administrator) &&
             !permissions.has(PermissionFlagsBits.ManageGuild)) {
-            await interaction.ephemeralReply('❌ Only administrators can decline terms for this server.');
+            await interaction.ephemeralReply(errorView('Only administrators can decline terms for this server.'));
             return;
         }
 
         const guild = interaction.guild;
         if (!guild) {
-            await interaction.ephemeralReply('❌ This can only be used in a server.');
+            await interaction.ephemeralReply(errorView('This can only be used in a server.'));
             return;
         }
 
         // Send farewell message
         await interaction.sendReply(
-            '👋 Terms declined. The bot will now leave this server. You can re-add the bot at any time if you change your mind.'
+            noticeView('Terms declined. The bot will now leave this server. You can re-add the bot at any time if you change your mind.')
         );
 
         // Leave the server

--- a/bot-service/src/_handlers/buttons/tests/question/skip.test.ts
+++ b/bot-service/src/_handlers/buttons/tests/question/skip.test.ts
@@ -54,7 +54,7 @@ describe('skip button handler', () => {
 
         await skip.execute(mockInteraction);
 
-        expect(mockInteraction.ephemeralFollowUp).toHaveBeenCalledWith(expect.stringContaining('Could not find tracking data'));
+        expect(mockInteraction.ephemeralFollowUp).toHaveBeenCalledWith(expect.objectContaining({ flags: expect.any(Number) }));
     });
 
     it('should reply with error when user is not the challenge owner', async () => {
@@ -62,7 +62,7 @@ describe('skip button handler', () => {
 
         await skip.execute(mockInteraction);
 
-        expect(mockInteraction.ephemeralFollowUp).toHaveBeenCalledWith(expect.stringContaining('Only the challenge recipient'));
+        expect(mockInteraction.ephemeralFollowUp).toHaveBeenCalledWith(expect.objectContaining({ flags: expect.any(Number) }));
     });
 
     it('should reply with error when challenge is already locked', async () => {
@@ -70,7 +70,7 @@ describe('skip button handler', () => {
 
         await skip.execute(mockInteraction);
 
-        expect(mockInteraction.ephemeralFollowUp).toHaveBeenCalledWith(expect.stringContaining('already been locked'));
+        expect(mockInteraction.ephemeralFollowUp).toHaveBeenCalledWith(expect.objectContaining({ flags: expect.any(Number) }));
     });
 
     it('should reply with no skips message when consume returns false', async () => {
@@ -78,7 +78,7 @@ describe('skip button handler', () => {
 
         await skip.execute(mockInteraction);
 
-        expect(mockInteraction.ephemeralFollowUp).toHaveBeenCalledWith(expect.stringContaining('no skips left'));
+        expect(mockInteraction.ephemeralFollowUp).toHaveBeenCalledWith(expect.objectContaining({ flags: expect.any(Number) }));
     });
 
     it('should finalize and update embed on happy path', async () => {

--- a/bot-service/src/_handlers/buttons/tests/setup/acceptRules.test.ts
+++ b/bot-service/src/_handlers/buttons/tests/setup/acceptRules.test.ts
@@ -55,7 +55,7 @@ describe('acceptRules button', () => {
 
     expect(serverService.acceptRules).toHaveBeenCalledWith('987654321');
     expect(channelSelectView).toHaveBeenCalled();
-    expect(botInteraction.sendReply).toHaveBeenCalledWith(null, mockMessage);
+    expect(botInteraction.sendReply).toHaveBeenCalledWith(mockMessage);
   });
 
   it('should reject non-admin users', async () => {
@@ -66,7 +66,7 @@ describe('acceptRules button', () => {
 
     expect(serverService.acceptRules).not.toHaveBeenCalled();
     expect(botInteraction.ephemeralReply).toHaveBeenCalledWith(
-      '❌ Only administrators can accept rules for this server.'
+      expect.objectContaining({ flags: expect.any(Number) })
     );
   });
 
@@ -78,7 +78,7 @@ describe('acceptRules button', () => {
 
     expect(serverService.acceptRules).not.toHaveBeenCalled();
     expect(botInteraction.ephemeralReply).toHaveBeenCalledWith(
-      '❌ This can only be used in a server.'
+      expect.objectContaining({ flags: expect.any(Number) })
     );
   });
 
@@ -90,7 +90,7 @@ describe('acceptRules button', () => {
 
     expect(serverService.acceptRules).not.toHaveBeenCalled();
     expect(botInteraction.ephemeralReply).toHaveBeenCalledWith(
-      '❌ This server is banned from using the bot. Reason: Hate Speech'
+      expect.objectContaining({ flags: expect.any(Number) })
     );
   });
 

--- a/bot-service/src/_handlers/buttons/tests/setup/acceptTerms.test.ts
+++ b/bot-service/src/_handlers/buttons/tests/setup/acceptTerms.test.ts
@@ -54,7 +54,7 @@ describe('acceptTerms button', () => {
 
     expect(serverService.acceptTerms).toHaveBeenCalledWith('987654321');
     expect(rulesView).toHaveBeenCalled();
-    expect(botInteraction.sendReply).toHaveBeenCalledWith(null, mockMessage);
+    expect(botInteraction.sendReply).toHaveBeenCalledWith(mockMessage);
   });
 
   it('should reject non-admin users', async () => {
@@ -65,7 +65,7 @@ describe('acceptTerms button', () => {
 
     expect(serverService.acceptTerms).not.toHaveBeenCalled();
     expect(botInteraction.ephemeralReply).toHaveBeenCalledWith(
-      '❌ Only administrators can accept terms for this server.'
+      expect.objectContaining({ flags: expect.any(Number) })
     );
   });
 

--- a/bot-service/src/_handlers/buttons/tests/setup/declineRules.test.ts
+++ b/bot-service/src/_handlers/buttons/tests/setup/declineRules.test.ts
@@ -46,7 +46,7 @@ describe('declineRules button', () => {
     await declineRulesButton.execute(botInteraction);
 
     expect(channelSelectView).toHaveBeenCalled();
-    expect(botInteraction.sendReply).toHaveBeenCalledWith(null, mockMessage);
+    expect(botInteraction.sendReply).toHaveBeenCalledWith(mockMessage);
   });
 
   it('should reject non-admin users', async () => {
@@ -56,7 +56,7 @@ describe('declineRules button', () => {
     await declineRulesButton.execute(botInteraction);
 
     expect(botInteraction.ephemeralReply).toHaveBeenCalledWith(
-      '❌ Only administrators can decline rules for this server.'
+      expect.objectContaining({ flags: expect.any(Number) })
     );
   });
 

--- a/bot-service/src/_handlers/buttons/tests/setup/declineTerms.test.ts
+++ b/bot-service/src/_handlers/buttons/tests/setup/declineTerms.test.ts
@@ -44,7 +44,7 @@ describe('declineTerms button', () => {
     await declineTermsButton.execute(botInteraction);
 
     expect(botInteraction.sendReply).toHaveBeenCalledWith(
-      '👋 Terms declined. The bot will now leave this server. You can re-add the bot at any time if you change your mind.'
+      expect.objectContaining({ flags: expect.any(Number) })
     );
     expect(mockGuild.leave).toHaveBeenCalled();
   });
@@ -57,7 +57,7 @@ describe('declineTerms button', () => {
 
     expect(mockGuild.leave).not.toHaveBeenCalled();
     expect(botInteraction.ephemeralReply).toHaveBeenCalledWith(
-      '❌ Only administrators can decline terms for this server.'
+      expect.objectContaining({ flags: expect.any(Number) })
     );
   });
 
@@ -69,7 +69,7 @@ describe('declineTerms button', () => {
 
     expect(mockGuild.leave).not.toHaveBeenCalled();
     expect(botInteraction.ephemeralReply).toHaveBeenCalledWith(
-      '❌ This can only be used in a server.'
+      expect.objectContaining({ flags: expect.any(Number) })
     );
   });
 

--- a/bot-service/src/_handlers/commands/global/create.ts
+++ b/bot-service/src/_handlers/commands/global/create.ts
@@ -1,7 +1,7 @@
 import { MessageFlags } from 'discord.js';
 import { questionService, serverService } from '../../../services';
 import { msClient } from '../../../client';
-import { BotCommandInteraction } from '@vulps22/bot-interactions';
+import { BotCommandInteraction, errorView } from '@vulps22/bot-interactions';
 import { QuestionType } from '@vulps22/project-encourage-types';
 import { Command } from '../../../utils';
 import { Logger } from '@vulps22/logger';
@@ -23,9 +23,7 @@ const create = new Command('create', 'Submit a custom truth or dare question')
 
     if (!interaction.guildId) {
       console.log(`[DEBUG /create] Rejected: no guildId`);
-      await interaction.editReply({
-        content: '❌ This command can only be used in a server.',
-      });
+      await interaction.sendReply(errorView('This command can only be used in a server.'));
       return;
     }
 
@@ -33,9 +31,7 @@ const create = new Command('create', 'Submit a custom truth or dare question')
     const canCreate = await serverService.canCreate(interaction.guildId);
     console.log(`[DEBUG /create] canCreate=${canCreate}`);
     if (!canCreate) {
-      await interaction.editReply({
-        content: '❌ This server is not allowed to create questions. It has either been blocked or has not accepted the rules yet.',
-      });
+      await interaction.sendReply(errorView('This server is not allowed to create questions. It has either been blocked or has not accepted the rules yet.'));
       return;
     }
 
@@ -48,9 +44,7 @@ const create = new Command('create', 'Submit a custom truth or dare question')
     console.log(`[DEBUG /create] questionService.createQuestion returned: ${typeof savedQuestion === 'string' ? `error="${savedQuestion}"` : `id=${savedQuestion.id}`}`);
 
     if (typeof savedQuestion === 'string') {
-      await interaction.editReply({
-        content: `❌ ${savedQuestion}`,
-      });
+      await interaction.sendReply(errorView(savedQuestion));
       return;
     }
 
@@ -62,7 +56,7 @@ const create = new Command('create', 'Submit a custom truth or dare question')
     const response = confirmNewQuestionEmbed(savedQuestion);
 
     // For now, just acknowledge
-    await interaction.sendReply(null, response);
+    await interaction.sendReply(response);
     console.log(`[DEBUG /create] Ephemeral confirmation sent to user ${interaction.user.id}`);
   });
 

--- a/bot-service/src/_handlers/commands/global/dare.ts
+++ b/bot-service/src/_handlers/commands/global/dare.ts
@@ -1,5 +1,5 @@
 import { challengeService, questionService, votingService } from '../../../services';
-import { BotCommandInteraction } from '@vulps22/bot-interactions';
+import { BotCommandInteraction, errorView } from '@vulps22/bot-interactions';
 import { QuestionType } from '@vulps22/project-encourage-types';
 import { Command } from '../../../utils';
 import { challengeEmbed } from '../../../views';
@@ -13,9 +13,7 @@ const dare = new Command('dare', 'Get a random dare question')
     const question = await questionService.getRandomQuestion(QuestionType.Dare);
 
     if (!question) {
-      await interaction.editReply({
-        content: '❌ No approved dare questions available. Try again later!',
-      });
+      await interaction.sendReply(errorView('No approved dare questions available. Try again later!'));
       return;
     }
 
@@ -30,7 +28,7 @@ const dare = new Command('dare', 'Get a random dare question')
 
     const votes = await votingService.addChallenge(challenge.id);
     const message = challengeEmbed(question, challenge, votes);
-    await interaction.sendReply(null, message);
+    await interaction.sendReply(message);
 
     const sentMessage = await interaction.fetchReply();
     await challengeService.setMessageId(challenge.id, sentMessage.id);

--- a/bot-service/src/_handlers/commands/global/help.ts
+++ b/bot-service/src/_handlers/commands/global/help.ts
@@ -7,7 +7,7 @@ const help = new Command('help', 'Display all available commands and features')
   .setAdministrator(false)
   .setExecute(async (interaction: BotCommandInteraction): Promise<void> => {
     const message = helpView();
-    await interaction.sendReply(null, message);
+    await interaction.sendReply(message);
   });
 
 export default help;

--- a/bot-service/src/_handlers/commands/global/random.ts
+++ b/bot-service/src/_handlers/commands/global/random.ts
@@ -1,5 +1,5 @@
 import { challengeService, questionService, votingService } from '../../../services';
-import { BotCommandInteraction } from '@vulps22/bot-interactions';
+import { BotCommandInteraction, errorView } from '@vulps22/bot-interactions';
 import { QuestionType } from '@vulps22/project-encourage-types';
 import { Command } from '../../../utils';
 import { challengeEmbed } from '../../../views';
@@ -14,9 +14,7 @@ const random = new Command('random', 'Get a random truth or dare question')
     const question = await questionService.getRandomQuestion(selectedType);
 
     if (!question) {
-      await interaction.editReply({
-        content: `❌ No approved ${selectedType} questions available. Try again later!`,
-      });
+      await interaction.sendReply(errorView(`No approved ${selectedType} questions available. Try again later!`));
       return;
     }
 
@@ -31,7 +29,7 @@ const random = new Command('random', 'Get a random truth or dare question')
 
     const votes = await votingService.addChallenge(challenge.id);
     const message = challengeEmbed(question, challenge, votes);
-    await interaction.sendReply(null, message);
+    await interaction.sendReply(message);
 
     const sentMessage = await interaction.fetchReply();
     await challengeService.setMessageId(challenge.id, sentMessage.id);

--- a/bot-service/src/_handlers/commands/global/report.ts
+++ b/bot-service/src/_handlers/commands/global/report.ts
@@ -1,6 +1,6 @@
 import { AutocompleteInteraction, MessageFlags } from "discord.js";
 import { dsClient, msClient } from "../../../client";
-import { BotCommandInteraction } from "@vulps22/bot-interactions";
+import { BotCommandInteraction, errorView, successView } from "@vulps22/bot-interactions";
 import { Command } from "../../../utils";
 import { TargetType, Question, Server } from "@vulps22/project-encourage-types";
 
@@ -54,12 +54,12 @@ const report = new Command('report', 'Report Inappropriate Content')
                 content = await getServer(interaction.guildId!);
                 break;
             default:
-                await interaction.ephemeralReply('❌ Invalid report type specified.');
+                await interaction.ephemeralReply(errorView('Invalid report type specified.'));
                 return;
         }
 
         if (!content) {
-            await interaction.ephemeralReply('❌ Content not found. If this is an Error, Please open a ticket on the [Official Server](https://discord.vulps.co.uk).');
+            await interaction.ephemeralReply(errorView('Content not found. If this is an Error, Please open a ticket on the [Official Server](https://discord.vulps.co.uk).'));
             return;
         }
 
@@ -76,7 +76,7 @@ const report = new Command('report', 'Report Inappropriate Content')
             interaction.options.getString('reason') ?? 'No reason provided'
         );
 
-        await interaction.ephemeralReply('✅ Report submitted successfully.');
+        await interaction.ephemeralReply(successView('Report submitted successfully.'));
     });
 
 export default report;

--- a/bot-service/src/_handlers/commands/global/rules.ts
+++ b/bot-service/src/_handlers/commands/global/rules.ts
@@ -9,7 +9,7 @@ const rules = new Command('rules', 'View the content rules for submitting truths
     .setExecute(async (interaction: BotCommandInteraction): Promise<void> => {
         await interaction.deferReply({ flags: MessageFlags.Ephemeral });
         const message = rulesView(false);
-        await interaction.sendReply(null, message);
+        await interaction.sendReply(message);
     });
 
 export default rules;

--- a/bot-service/src/_handlers/commands/global/setup.ts
+++ b/bot-service/src/_handlers/commands/global/setup.ts
@@ -1,6 +1,6 @@
 import { PermissionFlagsBits } from 'discord.js';
 import { serverService } from '../../../services';
-import { BotCommandInteraction } from '@vulps22/bot-interactions';
+import { BotCommandInteraction, errorView } from '@vulps22/bot-interactions';
 import { Command } from '../../../utils';
 import { termsView } from '../../../views';
 
@@ -11,14 +11,14 @@ const setup = new Command('setup', 'Configure server settings (Admin only)')
     // Check if user has admin permissions
     const member = interaction.member;
     if (!member || !('permissions' in member)) {
-      await interaction.ephemeralReply('❌ You need Administrator or Manage Server permissions to run this command.');
+      await interaction.ephemeralReply(errorView('You need Administrator or Manage Server permissions to run this command.'));
       return;
     }
 
     const permissions = member.permissions as import('discord.js').PermissionsBitField;
     if (!permissions.has(PermissionFlagsBits.Administrator) &&
         !permissions.has(PermissionFlagsBits.ManageGuild)) {
-      await interaction.ephemeralReply('❌ You need Administrator or Manage Server permissions to run this command.');
+      await interaction.ephemeralReply(errorView('You need Administrator or Manage Server permissions to run this command.'));
       return;
     }
 
@@ -29,7 +29,7 @@ const setup = new Command('setup', 'Configure server settings (Admin only)')
     const guild = interaction.guild;
 
     if (!guildId || !guild) {
-      await interaction.editReply({ content: '❌ This command can only be used in a server.' });
+      await interaction.sendReply(errorView('This command can only be used in a server.'));
       return;
     }
 
@@ -42,7 +42,7 @@ const setup = new Command('setup', 'Configure server settings (Admin only)')
 
     // Show terms view to start the setup wizard
     const message = termsView();
-    await interaction.sendReply(null, message);
+    await interaction.sendReply(message);
   });
 
 export default setup;

--- a/bot-service/src/_handlers/commands/global/truth.ts
+++ b/bot-service/src/_handlers/commands/global/truth.ts
@@ -1,5 +1,5 @@
 import { challengeService, questionService, votingService } from '../../../services';
-import { BotCommandInteraction } from '@vulps22/bot-interactions';
+import { BotCommandInteraction, errorView } from '@vulps22/bot-interactions';
 import { QuestionType } from '@vulps22/project-encourage-types';
 import { Command } from '../../../utils';
 import { challengeEmbed } from '../../../views';
@@ -13,9 +13,7 @@ const truth = new Command('truth', 'Get a random truth question')
     const question = await questionService.getRandomQuestion(QuestionType.Truth);
 
     if (!question) {
-      await interaction.editReply({
-        content: '❌ No approved truth questions available. Try again later!',
-      });
+      await interaction.sendReply(errorView('No approved truth questions available. Try again later!'));
       return;
     }
 
@@ -30,7 +28,7 @@ const truth = new Command('truth', 'Get a random truth question')
 
     const votes = await votingService.addChallenge(challenge.id);
     const message = challengeEmbed(question, challenge, votes);
-    await interaction.sendReply(null, message);
+    await interaction.sendReply(message);
 
     const sentMessage = await interaction.fetchReply();
     await challengeService.setMessageId(challenge.id, sentMessage.id);

--- a/bot-service/src/_handlers/commands/global/vote.ts
+++ b/bot-service/src/_handlers/commands/global/vote.ts
@@ -1,4 +1,4 @@
-import { BotCommandInteraction } from '@vulps22/bot-interactions';
+import { BotCommandInteraction, noticeView } from '@vulps22/bot-interactions';
 import { Command } from '../../../utils';
 import { inventoryService } from '../../../services';
 
@@ -11,8 +11,10 @@ const vote = new Command('vote', 'Check your skips and vote for the bot on Top.g
         const skips = inventory?.qty ?? 0;
 
         await interaction.ephemeralReply(
-            `🎟️ You have **${skips}** skip${skips !== 1 ? 's' : ''} remaining.\n\n` +
-            `Vote for the bot on [Top.gg](<${topggUrl}>) to earn more!`
+            noticeView(
+                `You have **${skips}** skip${skips !== 1 ? 's' : ''} remaining.\n\n` +
+                `Vote for the bot on [Top.gg](<${topggUrl}>) to earn more!`
+            )
         );
     });
 

--- a/bot-service/src/_handlers/commands/tests/global/create.test.ts
+++ b/bot-service/src/_handlers/commands/tests/global/create.test.ts
@@ -119,9 +119,9 @@ describe('create command', () => {
       await create.execute(mockInteraction as BotCommandInteraction);
 
       expect(questionService.createQuestion).not.toHaveBeenCalled();
-      expect(mockEditReply).toHaveBeenCalledWith({
-        content: '❌ This server is not allowed to create questions. It has either been blocked or has not accepted the rules yet.',
-      });
+      expect(mockSendReply).toHaveBeenCalledWith(
+        expect.objectContaining({ flags: expect.any(Number) })
+      );
     });
 
     it('should fail if not in a guild', async () => {
@@ -132,9 +132,9 @@ describe('create command', () => {
 
       await create.execute(noGuildInteraction as BotCommandInteraction);
 
-      expect(mockEditReply).toHaveBeenCalledWith({
-        content: '❌ This command can only be used in a server.',
-      });
+      expect(mockSendReply).toHaveBeenCalledWith(
+        expect.objectContaining({ flags: expect.any(Number) })
+      );
     });
 
     it('should get type and question from options', async () => {
@@ -179,10 +179,9 @@ describe('create command', () => {
 
       await create.execute(mockInteraction as BotCommandInteraction);
 
-      expect(mockEditReply).toHaveBeenCalledWith({
-        content: '❌ Question must be between 5 and 500 characters long.',
-      });
-      expect(mockSendReply).not.toHaveBeenCalled();
+      expect(mockSendReply).toHaveBeenCalledWith(
+        expect.objectContaining({ flags: expect.any(Number) })
+      );
     });
 
     it('should send success message on valid question', async () => {
@@ -213,7 +212,7 @@ describe('create command', () => {
       await create.execute(mockInteraction as BotCommandInteraction);
 
       expect(confirmNewQuestionEmbed).toHaveBeenCalledWith(savedQuestion);
-      expect(mockSendReply).toHaveBeenCalledWith(null, embedResponse);
+      expect(mockSendReply).toHaveBeenCalledWith(embedResponse);
     });
 
     it('should handle truth type', async () => {
@@ -276,9 +275,9 @@ describe('create command', () => {
       await create.execute(noGuildInteraction);
 
       expect(questionService.createQuestion).not.toHaveBeenCalled();
-      expect(mockEditReply).toHaveBeenCalledWith({
-        content: '❌ This command can only be used in a server.',
-      });
+      expect(mockSendReply).toHaveBeenCalledWith(
+        expect.objectContaining({ flags: expect.any(Number) })
+      );
     });
   });
 });

--- a/bot-service/src/_handlers/commands/tests/global/dare.test.ts
+++ b/bot-service/src/_handlers/commands/tests/global/dare.test.ts
@@ -90,19 +90,20 @@ describe('dare command', () => {
     expect(mockInteraction.deferReply).toHaveBeenCalled();
     expect(questionService.getRandomQuestion).toHaveBeenCalledWith(QuestionType.Dare);
     expect(challengeEmbed).toHaveBeenCalled();
-    expect(botInteraction.sendReply).toHaveBeenCalledWith(null, mockEmbedMessage);
+    expect(botInteraction.sendReply).toHaveBeenCalledWith(mockEmbedMessage);
   });
 
   it('should handle no approved questions available', async () => {
     (questionService.getRandomQuestion as jest.Mock).mockResolvedValue(null);
+    botInteraction.sendReply = jest.fn().mockResolvedValue(undefined);
 
     await dare.execute(botInteraction);
 
     expect(mockInteraction.deferReply).toHaveBeenCalled();
     expect(questionService.getRandomQuestion).toHaveBeenCalledWith(QuestionType.Dare);
-    expect(mockInteraction.editReply).toHaveBeenCalledWith({
-      content: '❌ No approved dare questions available. Try again later!',
-    });
+    expect(botInteraction.sendReply).toHaveBeenCalledWith(
+      expect.objectContaining({ flags: expect.any(Number) })
+    );
   });
 
   it('should have correct command properties', () => {

--- a/bot-service/src/_handlers/commands/tests/global/random.test.ts
+++ b/bot-service/src/_handlers/commands/tests/global/random.test.ts
@@ -101,7 +101,7 @@ describe('random command', () => {
     expect(mockInteraction.deferReply).toHaveBeenCalled();
     expect(questionService.getRandomQuestion).toHaveBeenCalledWith(QuestionType.Truth);
     expect(challengeEmbed).toHaveBeenCalled();
-    expect(botInteraction.sendReply).toHaveBeenCalledWith(null, mockEmbedMessage);
+    expect(botInteraction.sendReply).toHaveBeenCalledWith(mockEmbedMessage);
   });
 
   it('should send a random dare question when Math.random >= 0.5', async () => {
@@ -143,37 +143,37 @@ describe('random command', () => {
     expect(mockInteraction.deferReply).toHaveBeenCalled();
     expect(questionService.getRandomQuestion).toHaveBeenCalledWith(QuestionType.Dare);
     expect(challengeEmbed).toHaveBeenCalled();
-    expect(botInteraction.sendReply).toHaveBeenCalledWith(null, mockEmbedMessage);
+    expect(botInteraction.sendReply).toHaveBeenCalledWith(mockEmbedMessage);
   });
 
   it('should handle no approved truth questions available', async () => {
     // Mock Math.random to select Truth
     mathRandomSpy.mockReturnValue(0.3);
-
     (questionService.getRandomQuestion as jest.Mock).mockResolvedValue(null);
+    botInteraction.sendReply = jest.fn().mockResolvedValue(undefined);
 
     await random.execute(botInteraction);
 
     expect(mockInteraction.deferReply).toHaveBeenCalled();
     expect(questionService.getRandomQuestion).toHaveBeenCalledWith(QuestionType.Truth);
-    expect(mockInteraction.editReply).toHaveBeenCalledWith({
-      content: '❌ No approved truth questions available. Try again later!',
-    });
+    expect(botInteraction.sendReply).toHaveBeenCalledWith(
+      expect.objectContaining({ flags: expect.any(Number) })
+    );
   });
 
   it('should handle no approved dare questions available', async () => {
     // Mock Math.random to select Dare
     mathRandomSpy.mockReturnValue(0.7);
-
     (questionService.getRandomQuestion as jest.Mock).mockResolvedValue(null);
+    botInteraction.sendReply = jest.fn().mockResolvedValue(undefined);
 
     await random.execute(botInteraction);
 
     expect(mockInteraction.deferReply).toHaveBeenCalled();
     expect(questionService.getRandomQuestion).toHaveBeenCalledWith(QuestionType.Dare);
-    expect(mockInteraction.editReply).toHaveBeenCalledWith({
-      content: '❌ No approved dare questions available. Try again later!',
-    });
+    expect(botInteraction.sendReply).toHaveBeenCalledWith(
+      expect.objectContaining({ flags: expect.any(Number) })
+    );
   });
 
   it('should have correct command properties', () => {

--- a/bot-service/src/_handlers/commands/tests/global/report.test.ts
+++ b/bot-service/src/_handlers/commands/tests/global/report.test.ts
@@ -1,0 +1,214 @@
+import { ChatInputCommandInteraction } from 'discord.js';
+import { BotCommandInteraction } from '@vulps22/bot-interactions';
+import { dsClient, msClient } from '../../../../client';
+import { TargetType } from '@vulps22/project-encourage-types';
+import report from '../../global/report';
+
+jest.mock('../../../../client', () => ({
+    dsClient: {
+        searchQuestions: jest.fn().mockResolvedValue([]),
+        getQuestion: jest.fn(),
+        getServer: jest.fn(),
+    },
+    msClient: {
+        submitReport: jest.fn().mockResolvedValue(undefined),
+    },
+}));
+
+describe('report command', () => {
+    let mockInteraction: any;
+    let botInteraction: BotCommandInteraction;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+
+        mockInteraction = {
+            reply: jest.fn().mockResolvedValue(undefined),
+            editReply: jest.fn().mockResolvedValue(undefined),
+            deferReply: jest.fn().mockResolvedValue(undefined),
+            user: { id: '111222333444555666' },
+            guildId: '987654321098765432',
+            options: {
+                getSubcommand: jest.fn(),
+                getString: jest.fn(),
+            },
+        };
+
+        botInteraction = new BotCommandInteraction(
+            mockInteraction as ChatInputCommandInteraction,
+            'test-execution-id'
+        );
+        botInteraction.ephemeralReply = jest.fn().mockResolvedValue(undefined);
+    });
+
+    describe('command definition', () => {
+        it('should have correct name', () => {
+            expect(report.name).toBe('report');
+        });
+
+        it('should not be NSFW', () => {
+            expect(report.isNSFW).toBe(false);
+        });
+
+        it('should not require administrator', () => {
+            expect(report.isAdministrator).toBe(false);
+        });
+
+        it('should have question and server subcommands', () => {
+            const json = report.toJSON();
+            expect(json.options).toHaveLength(2);
+            const names = json.options.map((o: any) => o.name);
+            expect(names).toContain('question');
+            expect(names).toContain('server');
+        });
+    });
+
+    describe('question subcommand', () => {
+        beforeEach(() => {
+            mockInteraction.options.getSubcommand.mockReturnValue('question');
+        });
+
+        it('should defer reply with ephemeral flag', async () => {
+            mockInteraction.options.getString.mockReturnValue('42');
+            (dsClient.getQuestion as jest.Mock).mockResolvedValue({
+                id: 42,
+                question: 'What is your biggest secret?',
+            });
+
+            await report.execute(botInteraction);
+
+            expect(mockInteraction.deferReply).toHaveBeenCalled();
+        });
+
+        it('should submit question report and reply with success', async () => {
+            // getString('id') is called twice: once for getQuestion, once for offenderId
+            mockInteraction.options.getString
+                .mockReturnValueOnce('42')              // id (getQuestion)
+                .mockReturnValueOnce('42')              // id (offenderId)
+                .mockReturnValueOnce('Offensive content'); // reason
+
+            (dsClient.getQuestion as jest.Mock).mockResolvedValue({
+                id: 42,
+                question: 'What is your biggest secret?',
+            });
+
+            await report.execute(botInteraction);
+
+            expect(dsClient.getQuestion).toHaveBeenCalledWith(42);
+            expect(msClient.submitReport).toHaveBeenCalledWith(
+                '111222333444555666',
+                '42',
+                TargetType.Question,
+                '987654321098765432',
+                'What is your biggest secret?',
+                'Offensive content'
+            );
+            expect(botInteraction.ephemeralReply).toHaveBeenCalledWith(
+                expect.objectContaining({ flags: expect.any(Number) })
+            );
+        });
+
+        it('should send error view when question not found', async () => {
+            mockInteraction.options.getString.mockReturnValue('99');
+            (dsClient.getQuestion as jest.Mock).mockResolvedValue(null);
+
+            await report.execute(botInteraction);
+
+            expect(msClient.submitReport).not.toHaveBeenCalled();
+            expect(botInteraction.ephemeralReply).toHaveBeenCalledWith(
+                expect.objectContaining({ flags: expect.any(Number) })
+            );
+        });
+
+        it('should send error view when id is 0', async () => {
+            mockInteraction.options.getString.mockReturnValue('0');
+
+            await report.execute(botInteraction);
+
+            expect(dsClient.getQuestion).not.toHaveBeenCalled();
+            expect(msClient.submitReport).not.toHaveBeenCalled();
+            expect(botInteraction.ephemeralReply).toHaveBeenCalledWith(
+                expect.objectContaining({ flags: expect.any(Number) })
+            );
+        });
+
+        it('should use "No reason provided" as default reason', async () => {
+            // getString('id') is called twice: once for getQuestion, once for offenderId
+            mockInteraction.options.getString
+                .mockReturnValueOnce('42')  // id (getQuestion)
+                .mockReturnValueOnce('42')  // id (offenderId)
+                .mockReturnValueOnce(null); // reason (not provided)
+
+            (dsClient.getQuestion as jest.Mock).mockResolvedValue({
+                id: 42,
+                question: 'Test question?',
+            });
+
+            await report.execute(botInteraction);
+
+            expect(msClient.submitReport).toHaveBeenCalledWith(
+                expect.any(String),
+                expect.any(String),
+                expect.any(String),
+                expect.any(String),
+                expect.any(String),
+                'No reason provided'
+            );
+        });
+    });
+
+    describe('server subcommand', () => {
+        beforeEach(() => {
+            mockInteraction.options.getSubcommand.mockReturnValue('server');
+        });
+
+        it('should submit server report and reply with success', async () => {
+            mockInteraction.options.getString.mockReturnValue('Spam server');
+
+            (dsClient.getServer as jest.Mock).mockResolvedValue({
+                id: '987654321',
+                name: 'Test Server',
+            });
+
+            await report.execute(botInteraction);
+
+            expect(dsClient.getServer).toHaveBeenCalledWith('987654321098765432');
+            expect(msClient.submitReport).toHaveBeenCalledWith(
+                '111222333444555666',
+                '987654321098765432',
+                TargetType.Server,
+                '987654321098765432',
+                'Test Server',
+                'Spam server'
+            );
+            expect(botInteraction.ephemeralReply).toHaveBeenCalledWith(
+                expect.objectContaining({ flags: expect.any(Number) })
+            );
+        });
+
+        it('should send error view when server not found', async () => {
+            mockInteraction.options.getString.mockReturnValue(null);
+            (dsClient.getServer as jest.Mock).mockResolvedValue(null);
+
+            await report.execute(botInteraction);
+
+            expect(msClient.submitReport).not.toHaveBeenCalled();
+            expect(botInteraction.ephemeralReply).toHaveBeenCalledWith(
+                expect.objectContaining({ flags: expect.any(Number) })
+            );
+        });
+    });
+
+    describe('invalid subcommand', () => {
+        it('should send error view for unknown subcommand', async () => {
+            mockInteraction.options.getSubcommand.mockReturnValue('unknown');
+
+            await report.execute(botInteraction);
+
+            expect(msClient.submitReport).not.toHaveBeenCalled();
+            expect(botInteraction.ephemeralReply).toHaveBeenCalledWith(
+                expect.objectContaining({ flags: expect.any(Number) })
+            );
+        });
+    });
+});

--- a/bot-service/src/_handlers/commands/tests/global/rules.test.ts
+++ b/bot-service/src/_handlers/commands/tests/global/rules.test.ts
@@ -68,6 +68,6 @@ describe('rules command', () => {
 
     await rules.execute(botInteraction);
 
-    expect(botInteraction.sendReply).toHaveBeenCalledWith(null, mockMessage);
+    expect(botInteraction.sendReply).toHaveBeenCalledWith(mockMessage);
   });
 });

--- a/bot-service/src/_handlers/commands/tests/global/setup.test.ts
+++ b/bot-service/src/_handlers/commands/tests/global/setup.test.ts
@@ -76,7 +76,7 @@ describe('setup command', () => {
       '111222333'
     );
     expect(termsView).toHaveBeenCalled();
-    expect(botInteraction.sendReply).toHaveBeenCalledWith(null, mockTermsMessage);
+    expect(botInteraction.sendReply).toHaveBeenCalledWith(mockTermsMessage);
   });
 
   it('should reject non-admin users', async () => {

--- a/bot-service/src/_handlers/commands/tests/global/truth.test.ts
+++ b/bot-service/src/_handlers/commands/tests/global/truth.test.ts
@@ -90,19 +90,20 @@ describe('truth command', () => {
     expect(mockInteraction.deferReply).toHaveBeenCalled();
     expect(questionService.getRandomQuestion).toHaveBeenCalledWith(QuestionType.Truth);
     expect(challengeEmbed).toHaveBeenCalled();
-    expect(botInteraction.sendReply).toHaveBeenCalledWith(null, mockEmbedMessage);
+    expect(botInteraction.sendReply).toHaveBeenCalledWith(mockEmbedMessage);
   });
 
   it('should handle no approved questions available', async () => {
     (questionService.getRandomQuestion as jest.Mock).mockResolvedValue(null);
+    botInteraction.sendReply = jest.fn().mockResolvedValue(undefined);
 
     await truth.execute(botInteraction);
 
     expect(mockInteraction.deferReply).toHaveBeenCalled();
     expect(questionService.getRandomQuestion).toHaveBeenCalledWith(QuestionType.Truth);
-    expect(mockInteraction.editReply).toHaveBeenCalledWith({
-      content: '❌ No approved truth questions available. Try again later!',
-    });
+    expect(botInteraction.sendReply).toHaveBeenCalledWith(
+      expect.objectContaining({ flags: expect.any(Number) })
+    );
   });
 
   it('should have correct command properties', () => {

--- a/bot-service/src/_handlers/commands/tests/global/vote.test.ts
+++ b/bot-service/src/_handlers/commands/tests/global/vote.test.ts
@@ -1,0 +1,74 @@
+import { ChatInputCommandInteraction } from 'discord.js';
+import { BotCommandInteraction } from '@vulps22/bot-interactions';
+import { inventoryService } from '../../../../services';
+import vote from '../../global/vote';
+
+jest.mock('../../../../services', () => ({
+    inventoryService: {
+        get: jest.fn(),
+    },
+}));
+
+describe('vote command', () => {
+    let mockInteraction: any;
+    let botInteraction: BotCommandInteraction;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+
+        process.env.TOPGG_URL = 'https://top.gg/bot/123';
+
+        mockInteraction = {
+            reply: jest.fn().mockResolvedValue(undefined),
+            editReply: jest.fn().mockResolvedValue(undefined),
+            deferReply: jest.fn().mockResolvedValue(undefined),
+            user: { id: '123456789' },
+            guildId: '987654321',
+            options: {
+                getString: jest.fn(),
+            },
+        };
+
+        botInteraction = new BotCommandInteraction(
+            mockInteraction as ChatInputCommandInteraction,
+            'test-execution-id'
+        );
+        botInteraction.ephemeralReply = jest.fn().mockResolvedValue(undefined);
+    });
+
+    it('should have correct command properties', () => {
+        expect(vote.name).toBe('vote');
+        expect(vote.isNSFW).toBe(false);
+        expect(vote.isAdministrator).toBe(false);
+    });
+
+    it('should show skip count and top.gg link', async () => {
+        (inventoryService.get as jest.Mock).mockResolvedValue({ qty: 3 });
+
+        await vote.execute(botInteraction);
+
+        expect(inventoryService.get).toHaveBeenCalledWith('123456789', 'Skip');
+        expect(botInteraction.ephemeralReply).toHaveBeenCalledWith(
+            expect.objectContaining({ flags: expect.any(Number) })
+        );
+    });
+
+    it('should show 0 skips when inventory is empty', async () => {
+        (inventoryService.get as jest.Mock).mockResolvedValue(null);
+
+        await vote.execute(botInteraction);
+
+        expect(botInteraction.ephemeralReply).toHaveBeenCalledWith(
+            expect.objectContaining({ flags: expect.any(Number) })
+        );
+    });
+
+    it('should use qty from inventory when present', async () => {
+        (inventoryService.get as jest.Mock).mockResolvedValue({ qty: 5 });
+
+        await vote.execute(botInteraction);
+
+        expect(inventoryService.get).toHaveBeenCalledWith('123456789', 'Skip');
+        expect(botInteraction.ephemeralReply).toHaveBeenCalledTimes(1);
+    });
+});

--- a/bot-service/src/_handlers/modals/question/reportModal.ts
+++ b/bot-service/src/_handlers/modals/question/reportModal.ts
@@ -1,4 +1,4 @@
-import { BotModalInteraction } from '@vulps22/bot-interactions';
+import { BotModalInteraction, errorView, successView } from '@vulps22/bot-interactions';
 import { Handler } from '../../../utils';
 import { dsClient, msClient } from '../../../client';
 import { TargetType } from '@vulps22/project-encourage-types';
@@ -9,13 +9,13 @@ const reportModal: Handler<BotModalInteraction> = {
     async execute(interaction: BotModalInteraction): Promise<void> {
         const questionId = interaction.params.get(reportModal.params!.id);
         if (!questionId) {
-            await interaction.ephemeralReply('❌ Invalid question ID');
+            await interaction.ephemeralReply(errorView('Invalid question ID'));
             throw new Error('Invalid question ID when using Modal: question_reportModal');
         }
 
         const question = await dsClient.getQuestion(parseInt(questionId));
         if (!question) {
-            await interaction.ephemeralReply('❌ Question not found.');
+            await interaction.ephemeralReply(errorView('Question not found.'));
             return;
         }
 
@@ -30,7 +30,7 @@ const reportModal: Handler<BotModalInteraction> = {
             reason
         );
 
-        await interaction.ephemeralReply('✅ Report submitted successfully.');
+        await interaction.ephemeralReply(successView('Report submitted successfully.'));
     }
 };
 

--- a/bot-service/src/_handlers/modals/tests/question/reportModal.test.ts
+++ b/bot-service/src/_handlers/modals/tests/question/reportModal.test.ts
@@ -57,7 +57,7 @@ describe('reportModal', () => {
             'This is an inappropriate question.'
         );
         expect(mockInteraction.reply).toHaveBeenCalledWith(
-            expect.objectContaining({ content: '✅ Report submitted successfully.' })
+            expect.objectContaining({ flags: expect.any(Number) })
         );
     });
 
@@ -78,7 +78,7 @@ describe('reportModal', () => {
 
         expect(msClient.submitReport).not.toHaveBeenCalled();
         expect(mockInteraction.reply).toHaveBeenCalledWith(
-            expect.objectContaining({ content: '❌ Question not found.' })
+            expect.objectContaining({ flags: expect.any(Number) })
         );
     });
 });

--- a/bot-service/src/_handlers/selects/setup/announcementChannelSelected.ts
+++ b/bot-service/src/_handlers/selects/setup/announcementChannelSelected.ts
@@ -1,7 +1,7 @@
 import { NewsChannel, PermissionFlagsBits } from 'discord.js';
 import { Config } from '../../../config';
 import { serverService } from '../../../services';
-import { BotSelectMenuInteraction } from '@vulps22/bot-interactions';
+import { BotSelectMenuInteraction, errorView } from '@vulps22/bot-interactions';
 import { Handler } from '../../../utils';
 import { Logger } from '@vulps22/logger';
 import { setupCompleteView, setupFailedView } from '../../../views';
@@ -14,32 +14,32 @@ const announcementChannelSelected: Handler<BotSelectMenuInteraction> = {
         // Verify user is admin
         const member = interaction.member;
         if (!member || !('permissions' in member)) {
-            await interaction.ephemeralFollowUp('❌ Only administrators can configure announcement channels.');
+            await interaction.ephemeralFollowUp(errorView('Only administrators can configure announcement channels.'));
             return;
         }
         
         const permissions = member.permissions;
         if (typeof permissions === 'string') {
-            await interaction.ephemeralFollowUp('❌ Only administrators can configure announcement channels.');
+            await interaction.ephemeralFollowUp(errorView('Only administrators can configure announcement channels.'));
             return;
         }
         
         if (!permissions.has(PermissionFlagsBits.Administrator) &&
             !permissions.has(PermissionFlagsBits.ManageGuild)) {
-            await interaction.ephemeralFollowUp('❌ Only administrators can configure announcement channels.');
+            await interaction.ephemeralFollowUp(errorView('Only administrators can configure announcement channels.'));
             return;
         }
 
         const guildId = interaction.guildId;
         if (!guildId) {
-            await interaction.ephemeralFollowUp('❌ This can only be used in a server.');
+            await interaction.ephemeralFollowUp(errorView('This can only be used in a server.'));
             return;
         }
 
         // Get selected channel ID from the channel select menu
         const selectedChannelId = interaction.values[0];
         if (!selectedChannelId) {
-            await interaction.ephemeralFollowUp('❌ No channel was selected.');
+            await interaction.ephemeralFollowUp(errorView('No channel was selected.'));
             return;
         }
 

--- a/bot-service/src/events/interactionEvents/CommandInteractionEvent.ts
+++ b/bot-service/src/events/interactionEvents/CommandInteractionEvent.ts
@@ -1,5 +1,5 @@
 import { AutocompleteInteraction, ChatInputCommandInteraction } from "discord.js";
-import { BotCommandInteraction } from "@vulps22/bot-interactions";
+import { BotCommandInteraction, errorView } from "@vulps22/bot-interactions";
 import { Logger } from "@vulps22/logger";
 import { InteractionEvent } from "./InteractionEvent";
 
@@ -16,7 +16,7 @@ export class CommandInteractionEvent implements InteractionEvent<ChatInputComman
         const botInteraction = new BotCommandInteraction(interaction, executionId);
 
         if (command.isAdministrator && !botInteraction.isAdministrator()) {
-            await botInteraction.sendReply('❌ You do not have permission to use this command.');
+            await botInteraction.sendReply(errorView('You do not have permission to use this command.'));
             await Logger.updateExecution(executionId, 'Failed: Permission denied');
             return;
         }
@@ -31,7 +31,7 @@ export class CommandInteractionEvent implements InteractionEvent<ChatInputComman
             await Logger.updateExecution(executionId, `Failed: ${errorMessage}`);
 
             if (!interaction.replied && !interaction.deferred) {
-                await botInteraction.sendReply('❌ An error occurred while processing your command.').catch(() => null);
+                await botInteraction.sendReply(errorView('An error occurred while processing your command.')).catch(() => null);
             }
         }
     }

--- a/bot-service/src/events/tests/interactionEvents/CommandInteractionEvent.test.ts
+++ b/bot-service/src/events/tests/interactionEvents/CommandInteractionEvent.test.ts
@@ -1,0 +1,155 @@
+import { PermissionsBitField } from 'discord.js';
+import { BotCommandInteraction } from '@vulps22/bot-interactions';
+
+// Mock Logger before importing the event
+jest.mock('@vulps22/logger', () => ({
+    Logger: {
+        error: jest.fn(),
+        updateExecution: jest.fn().mockResolvedValue(undefined),
+    },
+}));
+
+const { CommandInteractionEvent } = require('../../interactionEvents/CommandInteractionEvent');
+const { Logger } = require('@vulps22/logger');
+
+describe('CommandInteractionEvent (bot-service)', () => {
+    let event: InstanceType<typeof CommandInteractionEvent>;
+    let mockDiscordInteraction: any;
+    let mockCommand: any;
+    let originalCommands: any;
+
+    beforeAll(() => {
+        originalCommands = (global as any).commands;
+    });
+
+    afterAll(() => {
+        (global as any).commands = originalCommands;
+    });
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+
+        event = new CommandInteractionEvent();
+
+        mockDiscordInteraction = {
+            commandName: 'truth',
+            user: { id: '123456789' },
+            guildId: '987654321',
+            replied: false,
+            deferred: false,
+            reply: jest.fn().mockResolvedValue(undefined),
+            deferReply: jest.fn().mockResolvedValue(undefined),
+            member: {
+                permissions: new PermissionsBitField(['Administrator']),
+            },
+            options: {
+                getString: jest.fn(),
+            },
+        };
+
+        mockCommand = {
+            name: 'truth',
+            isAdministrator: false,
+            execute: jest.fn().mockResolvedValue(undefined),
+            autoComplete: jest.fn().mockResolvedValue(undefined),
+        };
+
+        (global as any).commands = new Map();
+        (global as any).commands.set('truth', mockCommand);
+    });
+
+    describe('execute', () => {
+        it('should return early when command not found', async () => {
+            mockDiscordInteraction.commandName = 'unknown';
+
+            await event.execute(mockDiscordInteraction, 'exec-1');
+
+            expect(Logger.error).toHaveBeenCalledWith('No command found for name: unknown');
+            expect(mockCommand.execute).not.toHaveBeenCalled();
+        });
+
+        it('should send error view when user lacks administrator permission', async () => {
+            mockCommand.isAdministrator = true;
+            mockDiscordInteraction.member.permissions = new PermissionsBitField([]);
+
+            await event.execute(mockDiscordInteraction, 'exec-1');
+
+            expect(mockDiscordInteraction.reply).toHaveBeenCalledWith(
+                expect.objectContaining({ flags: expect.any(Number) })
+            );
+            expect(mockCommand.execute).not.toHaveBeenCalled();
+        });
+
+        it('should execute command for valid interaction', async () => {
+            await event.execute(mockDiscordInteraction, 'exec-1');
+
+            expect(mockCommand.execute).toHaveBeenCalledWith(expect.any(BotCommandInteraction));
+            expect(Logger.updateExecution).toHaveBeenCalledWith('exec-1', 'Success');
+        });
+
+        it('should send error view when command throws and interaction is not replied', async () => {
+            mockCommand.execute.mockRejectedValue(new Error('Something broke'));
+
+            await event.execute(mockDiscordInteraction, 'exec-1');
+
+            expect(Logger.error).toHaveBeenCalledWith(expect.stringContaining('Something broke'));
+            expect(mockDiscordInteraction.reply).toHaveBeenCalledWith(
+                expect.objectContaining({ flags: expect.any(Number) })
+            );
+        });
+
+        it('should not reply on error when interaction already replied', async () => {
+            mockDiscordInteraction.replied = true;
+            mockCommand.execute.mockRejectedValue(new Error('Something broke'));
+
+            await event.execute(mockDiscordInteraction, 'exec-1');
+
+            expect(mockDiscordInteraction.reply).not.toHaveBeenCalled();
+        });
+
+        it('should not reply on error when interaction already deferred', async () => {
+            mockDiscordInteraction.deferred = true;
+            mockCommand.execute.mockRejectedValue(new Error('Something broke'));
+
+            await event.execute(mockDiscordInteraction, 'exec-1');
+
+            expect(mockDiscordInteraction.reply).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('autocomplete', () => {
+        let mockAutocompleteInteraction: any;
+
+        beforeEach(() => {
+            mockAutocompleteInteraction = {
+                commandName: 'truth',
+                respond: jest.fn().mockResolvedValue(undefined),
+            };
+        });
+
+        it('should return early when command not found', async () => {
+            mockAutocompleteInteraction.commandName = 'unknown';
+
+            await event.autocomplete(mockAutocompleteInteraction);
+
+            expect(Logger.error).toHaveBeenCalledWith(
+                expect.stringContaining('No command found')
+            );
+        });
+
+        it('should call command autoComplete handler', async () => {
+            await event.autocomplete(mockAutocompleteInteraction);
+
+            expect(mockCommand.autoComplete).toHaveBeenCalledWith(mockAutocompleteInteraction);
+        });
+
+        it('should handle autoComplete errors gracefully', async () => {
+            mockCommand.autoComplete.mockRejectedValue(new Error('Autocomplete failed'));
+            const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+
+            await expect(event.autocomplete(mockAutocompleteInteraction)).resolves.not.toThrow();
+
+            consoleSpy.mockRestore();
+        });
+    });
+});

--- a/moderator-service/jest.config.js
+++ b/moderator-service/jest.config.js
@@ -1,7 +1,7 @@
 /** @type {import('jest').Config} */
 module.exports = {
   testEnvironment: 'node',
-  testMatch: ['<rootDir>/tests/**/*.test.ts'],
+  testMatch: ['<rootDir>/tests/**/*.test.ts', '<rootDir>/src/**/*.test.ts'],
   moduleFileExtensions: ['ts', 'js', 'json'],
   setupFiles: ['./tests/setup.ts'],
   transform: {

--- a/moderator-service/package-lock.json
+++ b/moderator-service/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@types/pg": "^8.11.11",
         "@types/supertest": "^7.2.0",
-        "@vulps22/bot-interactions": "^1.0.4",
+        "@vulps22/bot-interactions": "^1.1.0",
         "@vulps22/dynamic-endpoint-router": "^1.0.1",
         "@vulps22/project-encourage-types": "^1.0.0",
         "discord.js": "^14.16.3",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@vulps22/bot-interactions": {
-      "version": "1.0.4",
-      "resolved": "https://npm.pkg.github.com/download/@vulps22/bot-interactions/1.0.4/0b86da9884929ef0131732c67db95e56ece0fd2d",
-      "integrity": "sha512-/IfzULkr5MQc9Ck6/APo1kFFTJWOno0znK+xcVpbErr7aQyIcyqhpX34Mvfn4T4Vff10sILlpYWzS1DiKPPYMQ==",
+      "version": "1.1.0",
+      "resolved": "https://npm.pkg.github.com/download/@vulps22/bot-interactions/1.1.0/d388ab741541157c6490098720165ce42b79a71e",
+      "integrity": "sha512-/Qb3zjpdRh4jq9NTcTGILQg0X9VzxkKdQket3RaF/GibgGhMJFzrtndi0kjq20YFb75Y2RAu/Yxm7PTAhldktw==",
       "dependencies": {
         "@vulps22/logger": "^1.0.0",
         "discord.js": "^14.16.3"

--- a/moderator-service/package.json
+++ b/moderator-service/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@types/pg": "^8.11.11",
     "@types/supertest": "^7.2.0",
-    "@vulps22/bot-interactions": "^1.0.4",
+    "@vulps22/bot-interactions": "^1.1.0",
     "@vulps22/dynamic-endpoint-router": "^1.0.1",
     "@vulps22/project-encourage-types": "^1.0.0",
     "discord.js": "^14.16.3",

--- a/moderator-service/src/_handlers/buttons/moderation/actionReport.ts
+++ b/moderator-service/src/_handlers/buttons/moderation/actionReport.ts
@@ -1,5 +1,5 @@
 import { moderationService } from '../../../services';
-import { BotButtonInteraction } from '@vulps22/bot-interactions';
+import { BotButtonInteraction, errorView } from '@vulps22/bot-interactions';
 import { Handler, ModerationLogger } from '../../../bot/utils';
 
 /**
@@ -15,7 +15,7 @@ const actionReportButton: Handler<BotButtonInteraction> = {
         const reportId = parseInt(interaction.params.get('id') || '0');
         
         if (!reportId || reportId < 1) {
-            await interaction.ephemeralReply('❌ Invalid report ID.');
+            await interaction.ephemeralReply(errorView('Invalid report ID.'));
             return;
         }
 
@@ -35,7 +35,7 @@ const actionReportButton: Handler<BotButtonInteraction> = {
             });
 
         } catch (error) {
-            await interaction.ephemeralFollowUp(`❌ Failed to mark report as actioning: ${error instanceof Error ? error.message : 'Unknown error'}`);
+            await interaction.ephemeralFollowUp(errorView(`Failed to mark report as actioning: ${error instanceof Error ? error.message : 'Unknown error'}`));
         }
     }
 };

--- a/moderator-service/src/_handlers/buttons/moderation/approveQuestion.ts
+++ b/moderator-service/src/_handlers/buttons/moderation/approveQuestion.ts
@@ -2,7 +2,7 @@ import { Handler, Logger } from "../../../bot/utils";
 import { moderationService } from "../../../services";
 import { MetaQuestionBuilder } from "../../../bot/builders/MetaQuestionBuilder";
 import { LoggerService } from "../../../services/LoggerService";
-import { BotButtonInteraction } from "@vulps22/bot-interactions";
+import { BotButtonInteraction, errorView, successView } from "@vulps22/bot-interactions";
 import { QuestionType } from "@vulps22/project-encourage-types";
 import { newQuestionView } from "../../../views/moderation/newQuestionView";
 
@@ -12,7 +12,7 @@ const approveQuestionButton: Handler<BotButtonInteraction> = {
         const questionId = interaction.params.get("id");
 
         if (!questionId) {
-            await interaction.ephemeralReply('❌ Invalid question ID');
+            await interaction.ephemeralReply(errorView('Invalid question ID'));
             return;
         }
 
@@ -21,7 +21,7 @@ const approveQuestionButton: Handler<BotButtonInteraction> = {
 
             const meta = await new MetaQuestionBuilder().getMetaQuestion(Number(questionId));
             if (!meta) {
-                await interaction.ephemeralReply('❌ Question not found');
+                await interaction.ephemeralReply(errorView('Question not found'));
                 Logger.error(`Question with ID ${questionId} not found during approval for message ${interaction.message.id}`);
                 return;
             }
@@ -29,7 +29,7 @@ const approveQuestionButton: Handler<BotButtonInteraction> = {
             const { question, user, server } = meta;
 
             if (!question.message_id) {
-                await interaction.ephemeralReply('❌ Question has no associated log message');
+                await interaction.ephemeralReply(errorView('Question has no associated log message'));
                 return;
             }
 
@@ -39,11 +39,11 @@ const approveQuestionButton: Handler<BotButtonInteraction> = {
 
             const updatedView = await newQuestionView(question, undefined, user, server);
             await LoggerService.update(logChannelId, question.message_id, updatedView);
-            await interaction.sendReply('✅ Question approved successfully!');
+            await interaction.sendReply(successView('Question approved successfully!'));
 
         } catch (error) {
             console.error('Error approving question:', error);
-            await interaction.ephemeralReply('❌ Failed to approve question. Please try again.');
+            await interaction.ephemeralReply(errorView('Failed to approve question. Please try again.'));
         }
     }
 };

--- a/moderator-service/src/_handlers/buttons/moderation/banQuestion.ts
+++ b/moderator-service/src/_handlers/buttons/moderation/banQuestion.ts
@@ -2,7 +2,7 @@ import { Handler, ModerationLogger } from "../../../bot/utils";
 import { moderationService, questionService } from "../../../services";
 import { QuestionNotFoundError } from "../../../bot/errors/QuestionNotFoundError";
 import { QuestionType, TargetType } from "@vulps22/project-encourage-types";
-import { BotButtonInteraction } from "@vulps22/bot-interactions";
+import { BotButtonInteraction, errorView } from "@vulps22/bot-interactions";
 
 const approveQuestionButton: Handler<BotButtonInteraction> = {
     name: "banQuestion",
@@ -11,7 +11,7 @@ const approveQuestionButton: Handler<BotButtonInteraction> = {
         const reason = interaction.params.get("reason") || null;
 
         if (!questionId) {
-            await interaction.ephemeralReply('❌ Invalid question ID');
+            await interaction.ephemeralReply(errorView('Invalid question ID'));
             return;
         }
 

--- a/moderator-service/src/_handlers/buttons/moderation/banServer.ts
+++ b/moderator-service/src/_handlers/buttons/moderation/banServer.ts
@@ -1,5 +1,5 @@
 import { ServerProfileBuilder } from "../../../bot/builders/ServerProfileBuilder";
-import { BotButtonInteraction } from "@vulps22/bot-interactions";
+import { BotButtonInteraction, errorView } from "@vulps22/bot-interactions";
 import { Handler } from "../../../bot/utils";
 import { moderationService } from "../../../services";
 import { serverView } from "../../../views";
@@ -12,19 +12,19 @@ const banServerButton: Handler<BotButtonInteraction> = {
     async execute(interaction) {
         const serverId = interaction.params.get(banServerButton.params!.id);
         if (!serverId) {
-            await interaction.ephemeralReply('❌ Invalid server ID');
+            await interaction.ephemeralReply(errorView('Invalid server ID'));
             throw new Error('Invalid server ID when using Button: moderation_banServer');
         }
 
         const profile = await new ServerProfileBuilder().getServerProfile(serverId);
         if (!profile) {
-            await interaction.ephemeralReply('❌ Server not found');
+            await interaction.ephemeralReply(errorView('Server not found'));
             return;
         }
 
         const reasons = moderationService.getBanReasons(TargetType.Server);
         const view = await serverView(profile, reasons as []);
-        await interaction.updateComponentMessage(null, view);
+        await interaction.updateComponentMessage(view);
 
         interaction.message.awaitMessageComponent({
             filter: i => i.customId.startsWith(`moderation_serverBanReasonSelected`),

--- a/moderator-service/src/_handlers/buttons/moderation/banUser.ts
+++ b/moderator-service/src/_handlers/buttons/moderation/banUser.ts
@@ -1,5 +1,5 @@
 
-import { BotButtonInteraction } from "@vulps22/bot-interactions";
+import { BotButtonInteraction, errorView } from "@vulps22/bot-interactions";
 import { Handler } from "../../../bot/utils";
 import { moderationService } from "../../../services";
 import { userProfileView } from "../../../views";
@@ -13,21 +13,21 @@ const banUserButton: Handler<BotButtonInteraction> = {
     async execute(interaction) {
         const userId = interaction.params.get(banUserButton.params!.ID);
         if (!userId) {
-            await interaction.ephemeralReply('❌ Invalid user ID');
+            await interaction.ephemeralReply(errorView('Invalid user ID'));
             throw new Error('Invalid user ID when using Button: moderation_banUser');
         }
 
         // Get user profile
         const profile = await new UserProfileBuilder().getUserProfile(userId);
         if (!profile) {
-            await interaction.ephemeralReply('❌ User not found');
+            await interaction.ephemeralReply(errorView('User not found'));
             return;
         }
 
         // Get ban reasons and update message with dropdown
         const reasons = moderationService.getBanReasons(TargetType.User);
         const view = await userProfileView(profile, reasons);
-        await interaction.updateComponentMessage(null, view);
+        await interaction.updateComponentMessage(view);
 
         interaction.message.awaitMessageComponent({
             filter: i => i.customId.startsWith(`moderation_userBanReasonSelected`),

--- a/moderator-service/src/_handlers/buttons/moderation/clearReport.ts
+++ b/moderator-service/src/_handlers/buttons/moderation/clearReport.ts
@@ -1,5 +1,5 @@
 import { moderationService, reportService } from '../../../services';
-import { BotButtonInteraction } from '@vulps22/bot-interactions';
+import { BotButtonInteraction, errorView } from '@vulps22/bot-interactions';
 import { Handler } from '../../../bot/utils';
 
 /**
@@ -15,7 +15,7 @@ const clearReportButton: Handler<BotButtonInteraction> = {
         const reportId = parseInt(interaction.params.get('id') || '0');
         
         if (!reportId || reportId < 1) {
-            await interaction.ephemeralReply('❌ Invalid report ID.');
+            await interaction.ephemeralReply(errorView('Invalid report ID.'));
             return;
         }
 
@@ -35,7 +35,7 @@ const clearReportButton: Handler<BotButtonInteraction> = {
             );
 
         } catch (error) {
-            await interaction.ephemeralFollowUp(`❌ Failed to clear report: ${error instanceof Error ? error.message : 'Unknown error'}`);
+            await interaction.ephemeralFollowUp(errorView(`Failed to clear report: ${error instanceof Error ? error.message : 'Unknown error'}`));
         }
     }
 };

--- a/moderator-service/src/_handlers/buttons/moderation/sendToModerators.ts
+++ b/moderator-service/src/_handlers/buttons/moderation/sendToModerators.ts
@@ -1,6 +1,6 @@
 import { MessageCreateOptions, TextChannel } from "discord.js";
 import { Config } from "../../../bot/config";
-import { BotButtonInteraction } from "@vulps22/bot-interactions";
+import { BotButtonInteraction, errorView, successView } from "@vulps22/bot-interactions";
 import { Handler } from "../../../bot/utils";
 import { userProfileView } from "../../../views";
 import { UserProfileBuilder } from "../../../bot/builders/UserProfileBuilder";
@@ -11,19 +11,19 @@ const sendToModeratorsButton: Handler<BotButtonInteraction> = {
     async execute(interaction) {
         const userId = interaction.params.get(sendToModeratorsButton.params!.ID);
         if(!userId) {
-            await interaction.ephemeralReply('❌ Invalid user ID');
+            await interaction.ephemeralReply(errorView('Invalid user ID'));
             throw new Error('Invalid user ID when using Button: moderation_sendToModerators');
         }
         const profile = await new UserProfileBuilder().getUserProfile(userId);
         if(!profile) {
-            await interaction.ephemeralReply('❌ User not found');
+            await interaction.ephemeralReply(errorView('User not found'));
             return;
         }
 
         const view = await userProfileView(profile);
         const channel = await interaction.client.channels.fetch(Config.MOD_CHAT_CHANNEL_ID);
         if(!channel || !channel.isTextBased()) {
-            await interaction.ephemeralReply('❌ Mod chat channel not found');
+            await interaction.ephemeralReply(errorView('Mod chat channel not found'));
             throw new Error('Mod chat channel not found when using Button: moderation_sendToModerators');
         }
         const message = await (channel as TextChannel).send(view as MessageCreateOptions);
@@ -32,7 +32,7 @@ const sendToModeratorsButton: Handler<BotButtonInteraction> = {
         const guildId = (channel as TextChannel).guildId || '@me';
         const messageLink = `https://discord.com/channels/${guildId}/${channel.id}/${message.id}`;
 
-        await interaction.ephemeralReply(`✅ User profile sent to mod chat — [Go To Message](${messageLink})`);
+        await interaction.ephemeralReply(successView(`User profile sent to mod chat — [Go To Message](${messageLink})`));
     }
 };
 

--- a/moderator-service/src/_handlers/buttons/moderation/showUser.ts
+++ b/moderator-service/src/_handlers/buttons/moderation/showUser.ts
@@ -1,5 +1,5 @@
 import { UserProfileBuilder } from "../../../bot/builders/UserProfileBuilder";
-import { BotButtonInteraction } from "@vulps22/bot-interactions";
+import { BotButtonInteraction, errorView } from "@vulps22/bot-interactions";
 import { Handler } from "../../../bot/utils";
 import { userProfileView } from "../../../views";
 
@@ -9,17 +9,17 @@ const showUserButton: Handler<BotButtonInteraction> = {
     async execute(interaction) {
         const userId = interaction.params.get(showUserButton.params!.ID);
         if(!userId) {
-            await interaction.ephemeralReply('❌ Invalid user ID');
+            await interaction.ephemeralReply(errorView('Invalid user ID'));
             throw new Error('Invalid user ID when using Button: moderator_showUser');
         }
         const profile = await new UserProfileBuilder().getUserProfile(userId);
         if(!profile) {
-            await interaction.ephemeralReply('❌ User not found');
+            await interaction.ephemeralReply(errorView('User not found'));
             return;
         }
 
         const view = await userProfileView(profile);
-        await interaction.ephemeralReply(null, view);
+        await interaction.ephemeralReply(view);
 
     }
 };

--- a/moderator-service/src/_handlers/buttons/moderation/unbanServer.ts
+++ b/moderator-service/src/_handlers/buttons/moderation/unbanServer.ts
@@ -1,5 +1,5 @@
 import { ServerProfileBuilder } from "../../../bot/builders/ServerProfileBuilder";
-import { BotButtonInteraction } from "@vulps22/bot-interactions";
+import { BotButtonInteraction, errorView } from "@vulps22/bot-interactions";
 import { Handler, ModerationLogger } from "../../../bot/utils";
 import { serverService } from "../../../services";
 
@@ -9,7 +9,7 @@ const unbanServerButton: Handler<BotButtonInteraction> = {
     async execute(interaction) {
         const serverId = interaction.params.get(unbanServerButton.params!.id);
         if (!serverId) {
-            await interaction.ephemeralReply('❌ Invalid server ID');
+            await interaction.ephemeralReply(errorView('Invalid server ID'));
             throw new Error('Invalid server ID when using Button: moderation_unbanServer');
         }
 
@@ -20,7 +20,7 @@ const unbanServerButton: Handler<BotButtonInteraction> = {
 
         const profile = await new ServerProfileBuilder().getServerProfile(serverId);
         if (!profile) {
-            await interaction.ephemeralReply('❌ Server not found');
+            await interaction.ephemeralReply(errorView('Server not found'));
             return;
         }
 

--- a/moderator-service/src/_handlers/buttons/moderation/unbanUser.ts
+++ b/moderator-service/src/_handlers/buttons/moderation/unbanUser.ts
@@ -1,5 +1,5 @@
 import { UserProfileBuilder } from "../../../bot/builders/UserProfileBuilder";
-import { BotButtonInteraction } from "@vulps22/bot-interactions";
+import { BotButtonInteraction, errorView } from "@vulps22/bot-interactions";
 import { Handler, Logger } from "../../../bot/utils";
 import { questionService, serverService, userService } from "../../../services";
 import { userProfileView } from "../../../views";
@@ -10,7 +10,7 @@ const unbanUserButton: Handler<BotButtonInteraction> = {
     async execute(interaction) {
         const userId = interaction.params.get(unbanUserButton.params!.ID);
         if (!userId) {
-            await interaction.ephemeralReply('❌ Invalid user ID');
+            await interaction.ephemeralReply(errorView('Invalid user ID'));
             throw new Error('Invalid user ID when using Button: moderation_unbanUser');
         }
 
@@ -28,12 +28,12 @@ const unbanUserButton: Handler<BotButtonInteraction> = {
         // Refresh the profile view
         const profile = await new UserProfileBuilder().getUserProfile(userId);
         if (!profile) {
-            await interaction.ephemeralReply('❌ User not found');
+            await interaction.ephemeralReply(errorView('User not found'));
             return;
         }
 
         const view = await userProfileView(profile);
-        await interaction.sendReply(null, view);
+        await interaction.sendReply(view);
     }
 };
 

--- a/moderator-service/src/_handlers/buttons/moderation/viewOffender.ts
+++ b/moderator-service/src/_handlers/buttons/moderation/viewOffender.ts
@@ -1,5 +1,5 @@
 import { UserProfileBuilder } from "../../../bot/builders/UserProfileBuilder";
-import { BotButtonInteraction } from "@vulps22/bot-interactions";
+import { BotButtonInteraction, errorView } from "@vulps22/bot-interactions";
 import { Handler } from "../../../bot/utils";
 import { userProfileView } from "../../../views";
 
@@ -9,18 +9,18 @@ const viewOffenderButton: Handler<BotButtonInteraction> = {
     async execute(interaction) {
         const userId = interaction.params.get(viewOffenderButton.params!.id);
         if (!userId) {
-            await interaction.ephemeralReply('❌ Invalid user ID');
+            await interaction.ephemeralReply(errorView('Invalid user ID'));
             throw new Error('Invalid user ID when using Button: moderation_viewOffender');
         }
 
         const profile = await new UserProfileBuilder().getUserProfile(userId);
         if (!profile) {
-            await interaction.ephemeralReply('❌ User not found');
+            await interaction.ephemeralReply(errorView('User not found'));
             return;
         }
 
         const view = await userProfileView(profile);
-        await interaction.ephemeralReply(null, view);
+        await interaction.ephemeralReply(view);
     }
 };
 

--- a/moderator-service/src/_handlers/buttons/tests/moderation/actionReport.test.ts
+++ b/moderator-service/src/_handlers/buttons/tests/moderation/actionReport.test.ts
@@ -80,7 +80,7 @@ describe('actionReportButton', () => {
 
         expect(moderationService.actioningReport).not.toHaveBeenCalled();
         expect(mockInteraction.reply).toHaveBeenCalledWith(
-            expect.objectContaining({ content: '❌ Invalid report ID.' })
+            expect.objectContaining({ flags: expect.any(Number) })
         );
     });
 
@@ -104,7 +104,7 @@ describe('actionReportButton', () => {
         await actionReportButton.execute(botInteraction);
 
         expect(mockInteraction.followUp).toHaveBeenCalledWith(
-            expect.objectContaining({ content: '❌ Failed to mark report as actioning: Report not found' })
+            expect.objectContaining({ flags: expect.any(Number) })
         );
     });
 });

--- a/moderator-service/src/_handlers/buttons/tests/moderation/approveQuestion.test.ts
+++ b/moderator-service/src/_handlers/buttons/tests/moderation/approveQuestion.test.ts
@@ -82,7 +82,7 @@ describe('approveQuestion button handler', () => {
         expect(mockModerationService.approveQuestion).toHaveBeenCalledWith('123', '123456789012345678');
         expect(mockQuestionService.getQuestionById).toHaveBeenCalledWith(123);
         expect(mockLoggerService.update).toHaveBeenCalledWith('truths-channel-id', 'msg-789', expect.anything());
-        expect(mockButtonInteraction.sendReply).toHaveBeenCalledWith('✅ Question approved successfully!');
+        expect(mockButtonInteraction.sendReply).toHaveBeenCalledWith(expect.objectContaining({ flags: expect.any(Number) }));
         expect(mockButtonInteraction.ephemeralReply).not.toHaveBeenCalled();
     });
 
@@ -92,7 +92,7 @@ describe('approveQuestion button handler', () => {
         await approveQuestionButton.execute(mockButtonInteraction);
 
         expect(mockModerationService.approveQuestion).not.toHaveBeenCalled();
-        expect(mockButtonInteraction.ephemeralReply).toHaveBeenCalledWith('❌ Invalid question ID');
+        expect(mockButtonInteraction.ephemeralReply).toHaveBeenCalledWith(expect.objectContaining({ flags: expect.any(Number) }));
         expect(mockButtonInteraction.sendReply).not.toHaveBeenCalled();
     });
 
@@ -104,7 +104,7 @@ describe('approveQuestion button handler', () => {
 
         expect(mockModerationService.approveQuestion).toHaveBeenCalledWith('123', '123456789012345678');
         expect(console.error).toHaveBeenCalledWith('Error approving question:', testError);
-        expect(mockButtonInteraction.ephemeralReply).toHaveBeenCalledWith('❌ Failed to approve question. Please try again.');
+        expect(mockButtonInteraction.ephemeralReply).toHaveBeenCalledWith(expect.objectContaining({ flags: expect.any(Number) }));
         expect(mockButtonInteraction.sendReply).not.toHaveBeenCalled();
     });
 
@@ -116,7 +116,7 @@ describe('approveQuestion button handler', () => {
 
         expect(mockModerationService.approveQuestion).toHaveBeenCalledWith('123', '123456789012345678');
         expect(console.error).toHaveBeenCalledWith('Error approving question:', testError);
-        expect(mockButtonInteraction.ephemeralReply).toHaveBeenCalledWith('❌ Failed to approve question. Please try again.');
+        expect(mockButtonInteraction.ephemeralReply).toHaveBeenCalledWith(expect.objectContaining({ flags: expect.any(Number) }));
     });
 
     it('should use correct moderator ID from interaction', async () => {
@@ -150,7 +150,7 @@ describe('approveQuestion button handler', () => {
         expect(mockModerationService.approveQuestion).toHaveBeenCalledWith('123', '123456789012345678');
         expect(mockQuestionService.getQuestionById).toHaveBeenCalledWith(123);
         expect(mockLogger.error).toHaveBeenCalledWith('Question with ID 123 not found during approval for message message-456');
-        expect(mockButtonInteraction.ephemeralReply).toHaveBeenCalledWith('❌ Question not found');
+        expect(mockButtonInteraction.ephemeralReply).toHaveBeenCalledWith(expect.objectContaining({ flags: expect.any(Number) }));
         expect(mockButtonInteraction.sendReply).not.toHaveBeenCalled();
     });
 

--- a/moderator-service/src/_handlers/buttons/tests/moderation/banQuestion.test.ts
+++ b/moderator-service/src/_handlers/buttons/tests/moderation/banQuestion.test.ts
@@ -49,6 +49,7 @@ describe('banQuestion button handler', () => {
             action: 'banQuestion',
             params: new Map([['id', '123']]),
             ephemeralReply: jest.fn().mockResolvedValue(undefined),
+            deferUpdate: jest.fn().mockResolvedValue(undefined),
             message: {
                 awaitMessageComponent: jest.fn().mockResolvedValue({}),
             }
@@ -66,7 +67,7 @@ describe('banQuestion button handler', () => {
 
         await banQuestionButton.execute(mockButtonInteraction);
 
-        expect(mockButtonInteraction.ephemeralReply).toHaveBeenCalledWith('❌ Invalid question ID');
+        expect(mockButtonInteraction.ephemeralReply).toHaveBeenCalledWith(expect.objectContaining({ flags: expect.any(Number) }));
         expect(mockModerationService.getBanReasons).not.toHaveBeenCalled();
         expect(mockQuestionService.getQuestionById).not.toHaveBeenCalled();
     });

--- a/moderator-service/src/_handlers/buttons/tests/moderation/clearReport.test.ts
+++ b/moderator-service/src/_handlers/buttons/tests/moderation/clearReport.test.ts
@@ -72,7 +72,7 @@ describe('clearReportButton', () => {
 
         expect(moderationService.clearReport).not.toHaveBeenCalled();
         expect(mockInteraction.reply).toHaveBeenCalledWith(
-            expect.objectContaining({ content: '❌ Invalid report ID.' })
+            expect.objectContaining({ flags: expect.any(Number) })
         );
     });
 
@@ -82,7 +82,7 @@ describe('clearReportButton', () => {
         await clearReportButton.execute(botInteraction);
 
         expect(mockInteraction.followUp).toHaveBeenCalledWith(
-            expect.objectContaining({ content: '❌ Failed to clear report: Report not found after clearing' })
+            expect.objectContaining({ flags: expect.any(Number) })
         );
     });
 
@@ -92,7 +92,7 @@ describe('clearReportButton', () => {
         await clearReportButton.execute(botInteraction);
 
         expect(mockInteraction.followUp).toHaveBeenCalledWith(
-            expect.objectContaining({ content: '❌ Failed to clear report: DB error' })
+            expect.objectContaining({ flags: expect.any(Number) })
         );
     });
 });

--- a/moderator-service/src/_handlers/buttons/tests/moderation/sendToModerators.test.ts
+++ b/moderator-service/src/_handlers/buttons/tests/moderation/sendToModerators.test.ts
@@ -1,0 +1,142 @@
+import { BotButtonInteraction } from '@vulps22/bot-interactions';
+import sendToModeratorsButton from '../../moderation/sendToModerators';
+
+jest.mock('../../../../bot/builders/UserProfileBuilder', () => ({
+    UserProfileBuilder: jest.fn().mockImplementation(() => ({
+        getUserProfile: jest.fn(),
+    })),
+}));
+
+jest.mock('../../../../views', () => ({
+    userProfileView: jest.fn(),
+}));
+
+jest.mock('../../../../bot/config', () => ({
+    Config: {
+        MOD_CHAT_CHANNEL_ID: 'mod-chat-channel-id',
+    },
+}));
+
+import { UserProfileBuilder } from '../../../../bot/builders/UserProfileBuilder';
+import { userProfileView } from '../../../../views';
+
+describe('sendToModerators button handler', () => {
+    let mockInteraction: jest.Mocked<BotButtonInteraction>;
+    let mockGetUserProfile: jest.Mock;
+    let mockChannelFetch: jest.Mock;
+    let mockChannelSend: jest.Mock;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+
+        mockGetUserProfile = jest.fn();
+        (UserProfileBuilder as jest.Mock).mockImplementation(() => ({
+            getUserProfile: mockGetUserProfile,
+        }));
+
+        mockChannelSend = jest.fn().mockResolvedValue({
+            id: 'msg-999',
+        });
+
+        mockChannelFetch = jest.fn().mockResolvedValue({
+            isTextBased: () => true,
+            send: mockChannelSend,
+            id: 'mod-chat-channel-id',
+            guildId: '987654321',
+        });
+
+        mockInteraction = {
+            params: new Map([['id', 'user-123']]),
+            ephemeralReply: jest.fn().mockResolvedValue(undefined),
+            client: {
+                channels: {
+                    fetch: mockChannelFetch,
+                },
+            },
+        } as unknown as jest.Mocked<BotButtonInteraction>;
+    });
+
+    it('should have correct handler properties', () => {
+        expect(sendToModeratorsButton.name).toBe('sendToModerators');
+        expect(sendToModeratorsButton.params).toEqual({ ID: 'id' });
+    });
+
+    it('should send error view and throw when userId is missing', async () => {
+        (mockInteraction as any).params = new Map();
+
+        await expect(sendToModeratorsButton.execute(mockInteraction)).rejects.toThrow(
+            'Invalid user ID when using Button: moderation_sendToModerators'
+        );
+
+        expect(mockInteraction.ephemeralReply).toHaveBeenCalledWith(
+            expect.objectContaining({ flags: expect.any(Number) })
+        );
+    });
+
+    it('should send error view when user profile not found', async () => {
+        mockGetUserProfile.mockResolvedValue(null);
+
+        await sendToModeratorsButton.execute(mockInteraction);
+
+        expect(mockGetUserProfile).toHaveBeenCalledWith('user-123');
+        expect(mockInteraction.ephemeralReply).toHaveBeenCalledWith(
+            expect.objectContaining({ flags: expect.any(Number) })
+        );
+        expect(mockChannelFetch).not.toHaveBeenCalled();
+    });
+
+    it('should send error view and throw when mod chat channel not found', async () => {
+        const mockProfile = { userId: 'user-123', username: 'testuser' };
+        const mockView = { embeds: [], components: [] };
+
+        mockGetUserProfile.mockResolvedValue(mockProfile);
+        (userProfileView as jest.Mock).mockResolvedValue(mockView);
+        mockChannelFetch.mockResolvedValue(null);
+
+        await expect(sendToModeratorsButton.execute(mockInteraction)).rejects.toThrow(
+            'Mod chat channel not found when using Button: moderation_sendToModerators'
+        );
+
+        expect(mockInteraction.ephemeralReply).toHaveBeenCalledWith(
+            expect.objectContaining({ flags: expect.any(Number) })
+        );
+    });
+
+    it('should send error view and throw when channel is not text-based', async () => {
+        const mockProfile = { userId: 'user-123', username: 'testuser' };
+        const mockView = { embeds: [], components: [] };
+
+        mockGetUserProfile.mockResolvedValue(mockProfile);
+        (userProfileView as jest.Mock).mockResolvedValue(mockView);
+        mockChannelFetch.mockResolvedValue({
+            isTextBased: () => false,
+            id: 'voice-channel-id',
+        });
+
+        await expect(sendToModeratorsButton.execute(mockInteraction)).rejects.toThrow(
+            'Mod chat channel not found when using Button: moderation_sendToModerators'
+        );
+
+        expect(mockInteraction.ephemeralReply).toHaveBeenCalledWith(
+            expect.objectContaining({ flags: expect.any(Number) })
+        );
+    });
+
+    it('should send profile to mod chat and reply with success link', async () => {
+        const mockProfile = { userId: 'user-123', username: 'testuser' };
+        const mockView = { embeds: [], components: [] };
+
+        mockGetUserProfile.mockResolvedValue(mockProfile);
+        (userProfileView as jest.Mock).mockResolvedValue(mockView);
+
+        await sendToModeratorsButton.execute(mockInteraction);
+
+        expect(mockGetUserProfile).toHaveBeenCalledWith('user-123');
+        expect(userProfileView).toHaveBeenCalledWith(mockProfile);
+        expect(mockChannelFetch).toHaveBeenCalledWith('mod-chat-channel-id');
+        expect(mockChannelSend).toHaveBeenCalledWith(mockView);
+        expect(mockInteraction.ephemeralReply).toHaveBeenCalledWith(
+            expect.objectContaining({ flags: expect.any(Number) })
+        );
+    });
+});

--- a/moderator-service/src/_handlers/buttons/tests/moderation/showUser.test.ts
+++ b/moderator-service/src/_handlers/buttons/tests/moderation/showUser.test.ts
@@ -1,0 +1,76 @@
+import { BotButtonInteraction } from '@vulps22/bot-interactions';
+import showUserButton from '../../moderation/showUser';
+
+jest.mock('../../../../bot/builders/UserProfileBuilder', () => ({
+    UserProfileBuilder: jest.fn().mockImplementation(() => ({
+        getUserProfile: jest.fn(),
+    })),
+}));
+
+jest.mock('../../../../views', () => ({
+    userProfileView: jest.fn(),
+}));
+
+import { UserProfileBuilder } from '../../../../bot/builders/UserProfileBuilder';
+import { userProfileView } from '../../../../views';
+
+describe('showUser button handler', () => {
+    let mockInteraction: jest.Mocked<BotButtonInteraction>;
+    let mockGetUserProfile: jest.Mock;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+
+        mockGetUserProfile = jest.fn();
+        (UserProfileBuilder as jest.Mock).mockImplementation(() => ({
+            getUserProfile: mockGetUserProfile,
+        }));
+
+        mockInteraction = {
+            params: new Map([['id', 'user-123']]),
+            ephemeralReply: jest.fn().mockResolvedValue(undefined),
+        } as unknown as jest.Mocked<BotButtonInteraction>;
+    });
+
+    it('should have correct handler properties', () => {
+        expect(showUserButton.name).toBe('showUser');
+        expect(showUserButton.params).toEqual({ ID: 'id' });
+    });
+
+    it('should send error view when userId is missing', async () => {
+        (mockInteraction as any).params = new Map();
+
+        await expect(showUserButton.execute(mockInteraction)).rejects.toThrow(
+            'Invalid user ID when using Button: moderator_showUser'
+        );
+
+        expect(mockInteraction.ephemeralReply).toHaveBeenCalledWith(
+            expect.objectContaining({ flags: expect.any(Number) })
+        );
+    });
+
+    it('should send error view when user profile not found', async () => {
+        mockGetUserProfile.mockResolvedValue(null);
+
+        await showUserButton.execute(mockInteraction);
+
+        expect(mockGetUserProfile).toHaveBeenCalledWith('user-123');
+        expect(mockInteraction.ephemeralReply).toHaveBeenCalledWith(
+            expect.objectContaining({ flags: expect.any(Number) })
+        );
+    });
+
+    it('should send user profile view on success', async () => {
+        const mockProfile = { userId: 'user-123', username: 'testuser' };
+        const mockView = { embeds: [], components: [] };
+
+        mockGetUserProfile.mockResolvedValue(mockProfile);
+        (userProfileView as jest.Mock).mockResolvedValue(mockView);
+
+        await showUserButton.execute(mockInteraction);
+
+        expect(mockGetUserProfile).toHaveBeenCalledWith('user-123');
+        expect(userProfileView).toHaveBeenCalledWith(mockProfile);
+        expect(mockInteraction.ephemeralReply).toHaveBeenCalledWith(mockView);
+    });
+});

--- a/moderator-service/src/_handlers/modals/question/reportModal.ts
+++ b/moderator-service/src/_handlers/modals/question/reportModal.ts
@@ -1,4 +1,4 @@
-import { BotModalInteraction } from '@vulps22/bot-interactions';
+import { BotModalInteraction, errorView, successView } from '@vulps22/bot-interactions';
 import { Handler } from '../../../bot/utils';
 import { db, reportService } from '../../../services';
 import { TargetType } from '@vulps22/project-encourage-types';
@@ -9,13 +9,13 @@ const reportModal: Handler<BotModalInteraction> = {
     async execute(interaction: BotModalInteraction): Promise<void> {
         const questionId = interaction.params.get(reportModal.params!.id);
         if (!questionId) {
-            await interaction.ephemeralReply('❌ Invalid question ID');
+            await interaction.ephemeralReply(errorView('Invalid question ID'));
             throw new Error('Invalid question ID when using Modal: question_reportModal');
         }
 
         const question = await db.getQuestion(parseInt(questionId));
         if (!question) {
-            await interaction.ephemeralReply('❌ Question not found.');
+            await interaction.ephemeralReply(errorView('Question not found.'));
             return;
         }
 
@@ -30,7 +30,7 @@ const reportModal: Handler<BotModalInteraction> = {
             reason
         );
 
-        await interaction.ephemeralReply('✅ Report submitted successfully.');
+        await interaction.ephemeralReply(successView('Report submitted successfully.'));
     }
 };
 

--- a/moderator-service/src/_handlers/modals/tests/question/reportModal.test.ts
+++ b/moderator-service/src/_handlers/modals/tests/question/reportModal.test.ts
@@ -54,7 +54,7 @@ describe('reportModal', () => {
             'This is an inappropriate question.'
         );
         expect(mockInteraction.reply).toHaveBeenCalledWith(
-            expect.objectContaining({ content: '✅ Report submitted successfully.' })
+            expect.objectContaining({ flags: expect.any(Number) })
         );
     });
 
@@ -75,7 +75,7 @@ describe('reportModal', () => {
 
         expect(reportService.createReport).not.toHaveBeenCalled();
         expect(mockInteraction.reply).toHaveBeenCalledWith(
-            expect.objectContaining({ content: '❌ Question not found.' })
+            expect.objectContaining({ flags: expect.any(Number) })
         );
     });
 });

--- a/moderator-service/src/_handlers/selects/moderation/questionBanReasonSelected.ts
+++ b/moderator-service/src/_handlers/selects/moderation/questionBanReasonSelected.ts
@@ -1,5 +1,5 @@
 import { moderationService, questionService, reportService } from "../../../services";
-import { BotSelectMenuInteraction } from "@vulps22/bot-interactions";
+import { BotSelectMenuInteraction, errorView } from "@vulps22/bot-interactions";
 import { Handler, Logger, ModerationLogger } from "../../../bot/utils";
 import { QuestionType } from "@vulps22/project-encourage-types";
 
@@ -12,11 +12,11 @@ const questionBanReasonSelected: Handler<BotSelectMenuInteraction> = {
 
         if (!questionId) {
             Logger.error("Question ID not found when executing questionBanReasonSelected");
-            await interaction.ephemeralReply('❌ Invalid question ID');
+            await interaction.ephemeralReply(errorView('Invalid question ID'));
             return;
         }
         if (!selectedReason) {
-            await interaction.ephemeralReply('❌ No reason selected');
+            await interaction.ephemeralReply(errorView('No reason selected'));
             return;
         }
 
@@ -27,7 +27,7 @@ const questionBanReasonSelected: Handler<BotSelectMenuInteraction> = {
             const question = await questionService.getQuestionById(Number(questionId));
             if (!question) {
                 Logger.error(`Question with ID ${questionId} not found during banning for message ${interaction.message.id}`);
-                await interaction.ephemeralFollowUp('❌ Question not found');
+                await interaction.ephemeralFollowUp(errorView('Question not found'));
                 return;
             }
 
@@ -47,7 +47,7 @@ const questionBanReasonSelected: Handler<BotSelectMenuInteraction> = {
 
         } catch (error) {
             Logger.error(`Error banning question: ${JSON.stringify(error)}`);
-            await interaction.ephemeralFollowUp('❌ Failed to ban question. Please try again.');
+            await interaction.ephemeralFollowUp(errorView('Failed to ban question. Please try again.'));
         }
     }
 };

--- a/moderator-service/src/_handlers/selects/moderation/serverBanReasonSelected.ts
+++ b/moderator-service/src/_handlers/selects/moderation/serverBanReasonSelected.ts
@@ -1,5 +1,5 @@
 import { moderationService, reportService } from "../../../services";
-import { BotSelectMenuInteraction } from "@vulps22/bot-interactions";
+import { BotSelectMenuInteraction, errorView, successView } from "@vulps22/bot-interactions";
 import { Handler, Logger, ModerationLogger } from "../../../bot/utils";
 import { ServerProfileBuilder } from "../../../bot/builders/ServerProfileBuilder";
 
@@ -12,11 +12,11 @@ const serverBanReasonSelected: Handler<BotSelectMenuInteraction> = {
 
         if (!serverId) {
             Logger.error("Server ID not found when executing serverBanReasonSelected");
-            await interaction.ephemeralReply('❌ Invalid server ID');
+            await interaction.ephemeralReply(errorView('Invalid server ID'));
             return;
         }
         if (!selectedReason) {
-            await interaction.ephemeralReply('❌ No reason selected');
+            await interaction.ephemeralReply(errorView('No reason selected'));
             return;
         }
 
@@ -25,7 +25,7 @@ const serverBanReasonSelected: Handler<BotSelectMenuInteraction> = {
 
             const profile = await new ServerProfileBuilder().getServerProfile(serverId);
             if (!profile) {
-                await interaction.ephemeralReply('❌ Server not found');
+                await interaction.ephemeralReply(errorView('Server not found'));
                 Logger.error(`Server with ID ${serverId} not found during banning for message ${interaction.message.id}`);
                 return;
             }
@@ -41,11 +41,11 @@ const serverBanReasonSelected: Handler<BotSelectMenuInteraction> = {
                 );
             }
 
-            await interaction.ephemeralReply('✅ Server banned successfully!');
+            await interaction.ephemeralReply(successView('Server banned successfully!'));
 
         } catch (error) {
             console.error('Error banning server:', error);
-            await interaction.ephemeralReply('❌ Failed to ban server. Please try again.');
+            await interaction.ephemeralReply(errorView('Failed to ban server. Please try again.'));
         }
     }
 };

--- a/moderator-service/src/_handlers/selects/moderation/userBanReasonSelected.ts
+++ b/moderator-service/src/_handlers/selects/moderation/userBanReasonSelected.ts
@@ -1,5 +1,5 @@
 import { UserProfileBuilder } from "../../../bot/builders/UserProfileBuilder";
-import { BotSelectMenuInteraction } from "@vulps22/bot-interactions";
+import { BotSelectMenuInteraction, errorView } from "@vulps22/bot-interactions";
 import { Handler, Logger } from "../../../bot/utils";
 import { moderationService, questionService, reportService, serverService, userService } from "../../../services";
 import { userProfileView } from "../../../views";
@@ -13,12 +13,12 @@ const userBanReasonSelected: Handler<BotSelectMenuInteraction> = {
 
         if (!userId) {
             Logger.error("User ID not found when executing userBanReasonSelected");
-            await interaction.ephemeralReply('❌ Invalid user ID');
+            await interaction.ephemeralReply(errorView('Invalid user ID'));
             return;
         }
 
         if (!selectedReason) {
-            await interaction.ephemeralReply('❌ No reason selected');
+            await interaction.ephemeralReply(errorView('No reason selected'));
             return;
         }
 
@@ -43,13 +43,13 @@ async function banUser(userId: string, reason: string, interaction: BotSelectMen
         // Refresh the profile view
         const profile = await new UserProfileBuilder().getUserProfile(userId);
         if (!profile) {
-            await interaction.ephemeralReply('❌ User not found after banning');
+            await interaction.ephemeralReply(errorView('User not found after banning'));
             Logger.error(`User ${userId} not found after banning`);
             return;
         }
 
         const view = await userProfileView(profile);
-        await interaction.updateComponentMessage(null, view);
+        await interaction.updateComponentMessage(view);
 
         const reports = await moderationService.findActioningReports(userId);
         for (const report of reports) {
@@ -62,7 +62,7 @@ async function banUser(userId: string, reason: string, interaction: BotSelectMen
 
     } catch (error) {
         Logger.error(`Error banning user ${userId}: ${error instanceof Error ? error.message : 'Unknown error'}`);
-        await interaction.ephemeralReply('❌ Failed to ban user. Please try again.');
+        await interaction.ephemeralReply(errorView('Failed to ban user. Please try again.'));
     }
 }
 

--- a/moderator-service/src/_handlers/selects/tests/moderation/questionBanReasonSelected.test.ts
+++ b/moderator-service/src/_handlers/selects/tests/moderation/questionBanReasonSelected.test.ts
@@ -97,7 +97,7 @@ describe('questionBanReasonSelected select menu handler', () => {
 
         expect(mockSelectInteraction.deferUpdate).not.toHaveBeenCalled();
         expect(mockModerationService.banQuestion).not.toHaveBeenCalled();
-        expect(mockSelectInteraction.ephemeralReply).toHaveBeenCalledWith('❌ Invalid question ID');
+        expect(mockSelectInteraction.ephemeralReply).toHaveBeenCalledWith(expect.objectContaining({ flags: expect.any(Number) }));
         expect(mockLogger.error).toHaveBeenCalledWith('Question ID not found when executing questionBanReasonSelected');
     });
 
@@ -108,7 +108,7 @@ describe('questionBanReasonSelected select menu handler', () => {
 
         expect(mockSelectInteraction.deferUpdate).not.toHaveBeenCalled();
         expect(mockModerationService.banQuestion).not.toHaveBeenCalled();
-        expect(mockInteractionEmptyValues.ephemeralReply).toHaveBeenCalledWith('❌ No reason selected');
+        expect(mockInteractionEmptyValues.ephemeralReply).toHaveBeenCalledWith(expect.objectContaining({ flags: expect.any(Number) }));
     });
 
     it('should send ephemeral follow-up when question not found after banning', async () => {
@@ -119,7 +119,7 @@ describe('questionBanReasonSelected select menu handler', () => {
 
         expect(mockSelectInteraction.deferUpdate).toHaveBeenCalled();
         expect(mockLogger.error).toHaveBeenCalledWith('Question with ID 123 not found during banning for message message-456');
-        expect(mockSelectInteraction.ephemeralFollowUp).toHaveBeenCalledWith('❌ Question not found');
+        expect(mockSelectInteraction.ephemeralFollowUp).toHaveBeenCalledWith(expect.objectContaining({ flags: expect.any(Number) }));
     });
 
     it('should send ephemeral follow-up on service failure', async () => {
@@ -130,7 +130,7 @@ describe('questionBanReasonSelected select menu handler', () => {
 
         expect(mockSelectInteraction.deferUpdate).toHaveBeenCalled();
         expect(mockLogger.error).toHaveBeenCalledWith(`Error banning question: ${testError}`);
-        expect(mockSelectInteraction.ephemeralFollowUp).toHaveBeenCalledWith('❌ Failed to ban question. Please try again.');
+        expect(mockSelectInteraction.ephemeralFollowUp).toHaveBeenCalledWith(expect.objectContaining({ flags: expect.any(Number) }));
     });
 
     it('should use first value from values array', async () => {

--- a/moderator-service/src/_handlers/selects/tests/moderation/serverBanReasonSelected.test.ts
+++ b/moderator-service/src/_handlers/selects/tests/moderation/serverBanReasonSelected.test.ts
@@ -87,7 +87,7 @@ describe('serverBanReasonSelected select menu handler', () => {
         expect(mockModerationService.banServer).toHaveBeenCalledWith('987654321098765432', '123456789012345678', 'Hate Speech');
         expect(mockGetServerProfile).toHaveBeenCalledWith('987654321098765432');
         expect(mockModerationLogger.updateServerLog).toHaveBeenCalledWith(mockProfile);
-        expect(mockSelectInteraction.ephemeralReply).toHaveBeenCalledWith('✅ Server banned successfully!');
+        expect(mockSelectInteraction.ephemeralReply).toHaveBeenCalledWith(expect.objectContaining({ flags: expect.any(Number) }));
         expect(mockSelectInteraction.sendReply).not.toHaveBeenCalled();
     });
 
@@ -97,7 +97,7 @@ describe('serverBanReasonSelected select menu handler', () => {
         await serverBanReasonSelected.execute(mockSelectInteraction);
 
         expect(mockModerationService.banServer).not.toHaveBeenCalled();
-        expect(mockSelectInteraction.ephemeralReply).toHaveBeenCalledWith('❌ Invalid server ID');
+        expect(mockSelectInteraction.ephemeralReply).toHaveBeenCalledWith(expect.objectContaining({ flags: expect.any(Number) }));
         expect(mockLogger.error).toHaveBeenCalledWith('Server ID not found when executing serverBanReasonSelected');
     });
 
@@ -107,7 +107,7 @@ describe('serverBanReasonSelected select menu handler', () => {
         await serverBanReasonSelected.execute(mockInteractionEmptyValues as any);
 
         expect(mockModerationService.banServer).not.toHaveBeenCalled();
-        expect(mockInteractionEmptyValues.ephemeralReply).toHaveBeenCalledWith('❌ No reason selected');
+        expect(mockInteractionEmptyValues.ephemeralReply).toHaveBeenCalledWith(expect.objectContaining({ flags: expect.any(Number) }));
     });
 
     it('should reply ephemerally with error when server profile not found after banning', async () => {
@@ -117,7 +117,7 @@ describe('serverBanReasonSelected select menu handler', () => {
         await serverBanReasonSelected.execute(mockSelectInteraction);
 
         expect(mockLogger.error).toHaveBeenCalledWith('Server with ID 987654321098765432 not found during banning for message message-456');
-        expect(mockSelectInteraction.ephemeralReply).toHaveBeenCalledWith('❌ Server not found');
+        expect(mockSelectInteraction.ephemeralReply).toHaveBeenCalledWith(expect.objectContaining({ flags: expect.any(Number) }));
         expect(mockSelectInteraction.sendReply).not.toHaveBeenCalled();
     });
 
@@ -128,7 +128,7 @@ describe('serverBanReasonSelected select menu handler', () => {
         await serverBanReasonSelected.execute(mockSelectInteraction);
 
         expect(console.error).toHaveBeenCalledWith('Error banning server:', testError);
-        expect(mockSelectInteraction.ephemeralReply).toHaveBeenCalledWith('❌ Failed to ban server. Please try again.');
+        expect(mockSelectInteraction.ephemeralReply).toHaveBeenCalledWith(expect.objectContaining({ flags: expect.any(Number) }));
         expect(mockSelectInteraction.sendReply).not.toHaveBeenCalled();
     });
 

--- a/moderator-service/src/bot/events/interactionEvents/CommandInteractionEvent.ts
+++ b/moderator-service/src/bot/events/interactionEvents/CommandInteractionEvent.ts
@@ -1,5 +1,5 @@
 import { AutocompleteInteraction, ChatInputCommandInteraction } from "discord.js";
-import { BotCommandInteraction } from "@vulps22/bot-interactions";
+import { BotCommandInteraction, errorView } from "@vulps22/bot-interactions";
 import { Logger } from "../../utils";
 import { InteractionEvent } from "./InteractionEvent";
 
@@ -16,7 +16,7 @@ export class CommandInteractionEvent implements InteractionEvent<ChatInputComman
         const botInteraction = new BotCommandInteraction(interaction, executionId);
 
         if (command.isAdministrator && !botInteraction.isAdministrator()) {
-            await botInteraction.sendReply('❌ You do not have permission to use this command.');
+            await botInteraction.sendReply(errorView('You do not have permission to use this command.'));
             Logger.updateExecution(executionId, 'Failed: Permission denied');
             return;
         }
@@ -31,7 +31,7 @@ export class CommandInteractionEvent implements InteractionEvent<ChatInputComman
             Logger.updateExecution(executionId, `Failed: ${errorMessage}`);
 
             if (!interaction.replied && !interaction.deferred) {
-                await botInteraction.sendReply('❌ An error occurred while processing your command.').catch(() => null);
+                await botInteraction.sendReply(errorView('An error occurred while processing your command.')).catch(() => null);
             }
         }
     }

--- a/moderator-service/src/bot/events/tests/interactionEvents/CommandInteractionEvent.test.ts
+++ b/moderator-service/src/bot/events/tests/interactionEvents/CommandInteractionEvent.test.ts
@@ -1,0 +1,155 @@
+import { ChatInputCommandInteraction, PermissionsBitField } from 'discord.js';
+import { BotCommandInteraction } from '@vulps22/bot-interactions';
+
+// Mock Logger before importing the event
+jest.mock('../../../utils', () => ({
+    Logger: {
+        error: jest.fn(),
+        updateExecution: jest.fn(),
+    },
+}));
+
+const { CommandInteractionEvent } = require('../../interactionEvents/CommandInteractionEvent');
+const { Logger } = require('../../../utils');
+
+describe('CommandInteractionEvent (moderator-service)', () => {
+    let event: InstanceType<typeof CommandInteractionEvent>;
+    let mockDiscordInteraction: any;
+    let mockCommand: any;
+    let originalCommands: any;
+
+    beforeAll(() => {
+        originalCommands = (global as any).commands;
+    });
+
+    afterAll(() => {
+        (global as any).commands = originalCommands;
+    });
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+
+        event = new CommandInteractionEvent();
+
+        mockDiscordInteraction = {
+            commandName: 'ban',
+            user: { id: '123456789' },
+            guildId: '987654321',
+            replied: false,
+            deferred: false,
+            reply: jest.fn().mockResolvedValue(undefined),
+            deferReply: jest.fn().mockResolvedValue(undefined),
+            member: {
+                permissions: new PermissionsBitField(['Administrator']),
+            },
+            options: {
+                getString: jest.fn(),
+            },
+        };
+
+        mockCommand = {
+            name: 'ban',
+            isAdministrator: false,
+            execute: jest.fn().mockResolvedValue(undefined),
+            autoComplete: jest.fn().mockResolvedValue(undefined),
+        };
+
+        (global as any).commands = new Map();
+        (global as any).commands.set('ban', mockCommand);
+    });
+
+    describe('execute', () => {
+        it('should return early when command not found', async () => {
+            mockDiscordInteraction.commandName = 'unknown';
+
+            await event.execute(mockDiscordInteraction, 'exec-1');
+
+            expect(Logger.error).toHaveBeenCalledWith('No command found for name: unknown');
+            expect(mockCommand.execute).not.toHaveBeenCalled();
+        });
+
+        it('should send error view when user lacks administrator permission', async () => {
+            mockCommand.isAdministrator = true;
+            mockDiscordInteraction.member.permissions = new PermissionsBitField([]);
+
+            await event.execute(mockDiscordInteraction, 'exec-1');
+
+            expect(mockDiscordInteraction.reply).toHaveBeenCalledWith(
+                expect.objectContaining({ flags: expect.any(Number) })
+            );
+            expect(mockCommand.execute).not.toHaveBeenCalled();
+        });
+
+        it('should execute command for valid interaction', async () => {
+            await event.execute(mockDiscordInteraction, 'exec-1');
+
+            expect(mockCommand.execute).toHaveBeenCalledWith(expect.any(BotCommandInteraction));
+            expect(Logger.updateExecution).toHaveBeenCalledWith('exec-1', 'Success');
+        });
+
+        it('should send error view when command throws and interaction is not replied', async () => {
+            mockCommand.execute.mockRejectedValue(new Error('Something broke'));
+
+            await event.execute(mockDiscordInteraction, 'exec-1');
+
+            expect(Logger.error).toHaveBeenCalledWith(expect.stringContaining('Something broke'));
+            expect(mockDiscordInteraction.reply).toHaveBeenCalledWith(
+                expect.objectContaining({ flags: expect.any(Number) })
+            );
+        });
+
+        it('should not reply on error when interaction already replied', async () => {
+            mockDiscordInteraction.replied = true;
+            mockCommand.execute.mockRejectedValue(new Error('Something broke'));
+
+            await event.execute(mockDiscordInteraction, 'exec-1');
+
+            expect(mockDiscordInteraction.reply).not.toHaveBeenCalled();
+        });
+
+        it('should not reply on error when interaction already deferred', async () => {
+            mockDiscordInteraction.deferred = true;
+            mockCommand.execute.mockRejectedValue(new Error('Something broke'));
+
+            await event.execute(mockDiscordInteraction, 'exec-1');
+
+            expect(mockDiscordInteraction.reply).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('autocomplete', () => {
+        let mockAutocompleteInteraction: any;
+
+        beforeEach(() => {
+            mockAutocompleteInteraction = {
+                commandName: 'ban',
+                respond: jest.fn().mockResolvedValue(undefined),
+            };
+        });
+
+        it('should return early when command not found', async () => {
+            mockAutocompleteInteraction.commandName = 'unknown';
+
+            await event.autocomplete(mockAutocompleteInteraction);
+
+            expect(Logger.error).toHaveBeenCalledWith(
+                expect.stringContaining('No command found')
+            );
+        });
+
+        it('should call command autoComplete handler', async () => {
+            await event.autocomplete(mockAutocompleteInteraction);
+
+            expect(mockCommand.autoComplete).toHaveBeenCalledWith(mockAutocompleteInteraction);
+        });
+
+        it('should handle autoComplete errors gracefully', async () => {
+            mockCommand.autoComplete.mockRejectedValue(new Error('Autocomplete failed'));
+            const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+
+            await expect(event.autocomplete(mockAutocompleteInteraction)).resolves.not.toThrow();
+
+            consoleSpy.mockRestore();
+        });
+    });
+});

--- a/scripts/maintenance-bot.js
+++ b/scripts/maintenance-bot.js
@@ -1,0 +1,11 @@
+const { ShardingManager } = require('discord.js');
+const path = require('path');
+
+const manager = new ShardingManager(path.join(__dirname, 'maintenance-worker.js'), {
+  token: process.env.PE_DISCORD_TOKEN,
+  totalShards: 'auto',
+});
+
+manager.on('shardCreate', (shard) => console.log(`Launched shard ${shard.id}`));
+
+manager.spawn();

--- a/scripts/maintenance-worker.js
+++ b/scripts/maintenance-worker.js
@@ -1,0 +1,25 @@
+const { Client, GatewayIntentBits, ActivityType } = require('discord.js');
+
+const client = new Client({ intents: [GatewayIntentBits.Guilds] });
+
+client.once('ready', () => {
+  console.log(`Maintenance mode active as ${client.user.tag} (shard ${client.shard.ids})`);
+  client.user.setPresence({
+    status: 'dnd',
+    activities: [{ name: '🔧 Under Maintenance', type: ActivityType.Custom }],
+  });
+});
+
+client.on('interactionCreate', async (interaction) => {
+  if (!interaction.isRepliable()) return;
+  try {
+    await interaction.reply({
+      content: '🔧 **Truth or Dare Online 18+ is currently undergoing maintenance.**\nCheck for updates at https://status.vulps.co.uk',
+      ephemeral: true,
+    });
+  } catch (err) {
+    console.error('Failed to reply:', err.message);
+  }
+});
+
+client.login(process.env.PE_DISCORD_TOKEN);


### PR DESCRIPTION
## Summary
- Replaced all deprecated `sendReply(content, options)` calls across bot-service and moderator-service with the new V2 view factory API (`noticeView`, `successView`, `errorView`)
- Updated moderator-service `jest.config.js` to include `src/**/*.test.ts` so previously-hidden test suites now run
- Added missing test files for untested handlers (`report`, `vote`, `CommandInteractionEvent`, `showUser`, `sendToModerators`)
- Fixed test assertions throughout both services to match V2 view output (`objectContaining({ flags })` instead of string content checks)

## Test plan
- [ ] `npm test` in `bot-service` — all 40 suites pass, no deprecation warnings
- [ ] `npm test` in `moderator-service` — migration-related suites pass; pre-existing failures tracked in #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)