### PR TITLE
#125 - Add post-release changelog, freeze preview, and project automations

### DIFF
--- a/.github/scripts/post-changelog.sh
+++ b/.github/scripts/post-changelog.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TYPE="$1"         # freeze | release | hotfix
+VERSION="$2"      # e.g. v2026.6.2 or v2026.6.2-H1
+WEBHOOK_URL="$3"
+REPO="$4"
+
+# ── Determine last tag ────────────────────────────────────────────────────────
+
+if [ "$TYPE" = "hotfix" ]; then
+  # Strip -HN suffix: v2026.6.1-H1 → v2026.6.1, v2026.6.1-H2 → v2026.6.1
+  LAST_TAG=$(echo "$VERSION" | sed 's/-H[0-9]*$//')
+else
+  # freeze or release: last non-H release tag, excluding the version just tagged
+  LAST_TAG=$(git tag -l 'v[0-9]*' | grep -v '\-H' | sort -V | grep -v "^${VERSION}$" | tail -1)
+fi
+
+if [ -z "$LAST_TAG" ]; then
+  echo "No previous tag found — collecting all merged PRs"
+  MERGE_RANGE="HEAD"
+else
+  echo "Collecting PRs since $LAST_TAG"
+  MERGE_RANGE="${LAST_TAG}..HEAD"
+fi
+
+# ── Collect PR numbers from git log merge commits ─────────────────────────────
+
+PR_NUMBERS=$(git log "$MERGE_RANGE" --merges --format="%s" \
+  | grep -oE 'pull request #[0-9]+' \
+  | grep -oE '[0-9]+' \
+  | sort -n) || true
+
+if [ -z "$PR_NUMBERS" ]; then
+  echo "No merged PRs found since ${LAST_TAG:-beginning} — skipping Discord notification"
+  exit 0
+fi
+
+# ── Build changelog lines ─────────────────────────────────────────────────────
+
+TITLE_PATTERN='^#[0-9]+ - (Add|Remove|Update|Revert|Refactor) .+'
+CHANGELOG_LINES=""
+
+for PR_NUM in $PR_NUMBERS; do
+  PR_JSON=$(gh pr view "$PR_NUM" --repo "$REPO" --json number,title 2>/dev/null) || {
+    echo "Could not fetch PR #$PR_NUM — skipping"
+    continue
+  }
+  PR_TITLE=$(echo "$PR_JSON" | jq -r '.title')
+
+  if ! echo "$PR_TITLE" | grep -qE "$TITLE_PATTERN"; then
+    echo "Skipping PR #$PR_NUM — title does not match format: $PR_TITLE"
+    continue
+  fi
+
+  # Extract issue number and summary from PR title: "#126 - Update foo bar"
+  ISSUE_NUM=$(echo "$PR_TITLE" | grep -oE '^#[0-9]+' | tr -d '#')
+  SUMMARY=$(echo "$PR_TITLE" | sed 's/^#[0-9]* - //')
+  VERB=$(echo "$SUMMARY" | awk '{print $1}')
+
+  case "$VERB" in
+    Add|Update|Refactor) SYMBOL="+" ;;
+    Remove|Revert)       SYMBOL="-" ;;
+    *)                   SYMBOL="~" ;;
+  esac
+
+  ISSUE_URL="https://github.com/${REPO}/issues/${ISSUE_NUM}"
+  LINE="${SYMBOL} ${SUMMARY} ([#${ISSUE_NUM}](${ISSUE_URL}))"
+
+  if [ -n "$CHANGELOG_LINES" ]; then
+    CHANGELOG_LINES="${CHANGELOG_LINES}\n${LINE}"
+  else
+    CHANGELOG_LINES="$LINE"
+  fi
+done
+
+if [ -z "$CHANGELOG_LINES" ]; then
+  echo "No conforming PRs found — skipping Discord notification"
+  exit 0
+fi
+
+# ── Build embed title, description, and colour per type ──────────────────────
+
+case "$TYPE" in
+  freeze)
+    EMBED_TITLE="Freeze Preview — ${VERSION}"
+    EMBED_COLOR=3447003
+    DESCRIPTION="The following changes are queued for release in **${VERSION}**:"
+    ;;
+  release)
+    EMBED_TITLE="Release ${VERSION}"
+    EMBED_COLOR=3066993
+    DESCRIPTION="The following changes shipped in **${VERSION}**:"
+    ;;
+  hotfix)
+    EMBED_TITLE="Hotfix ${VERSION}"
+    EMBED_COLOR=15158332
+    DESCRIPTION="The following hotfix changes shipped in **${VERSION}**:"
+    ;;
+esac
+
+# ── POST to Discord ───────────────────────────────────────────────────────────
+
+CHANGELOG_BODY=$(printf '%b' "$CHANGELOG_LINES")
+
+PAYLOAD=$(jq -n \
+  --arg title "$EMBED_TITLE" \
+  --arg desc "$DESCRIPTION" \
+  --arg body "$CHANGELOG_BODY" \
+  --argjson color "$EMBED_COLOR" \
+  '{embeds: [{title: $title, description: ($desc + "\n\n" + $body), color: $color}]}')
+
+echo "Posting changelog to Discord..."
+HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+  -H "Content-Type: application/json" \
+  -d "$PAYLOAD" \
+  "$WEBHOOK_URL")
+
+if [ "$HTTP_STATUS" -ge 200 ] && [ "$HTTP_STATUS" -lt 300 ]; then
+  echo "Discord notification sent (HTTP $HTTP_STATUS)"
+else
+  echo "ERROR: Discord webhook returned HTTP $HTTP_STATUS" >&2
+  exit 1
+fi

--- a/.github/scripts/update-project-status.sh
+++ b/.github/scripts/update-project-status.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# update-project-status.sh
+# Usage: update-project-status.sh <issue_number> <status_option_id>
+set -euo pipefail
+
+ISSUE_NUMBER="$1"
+STATUS_OPTION_ID="$2"
+REPO="${GITHUB_REPOSITORY:-Vulps22/project-encourage-reborn}"
+PROJECT_ID="PVT_kwHOACitxM4BbRy3"
+STATUS_FIELD_ID="PVTSSF_lAHOACitxM4BbRy3zhWDZUs"
+
+# ── Find the project item ID for this issue ───────────────────────────────────
+
+OWNER="${REPO%%/*}"
+REPO_NAME="${REPO##*/}"
+
+ITEM_ID=$(gh api graphql -f query="
+{
+  repository(owner: \"${OWNER}\", name: \"${REPO_NAME}\") {
+    issue(number: ${ISSUE_NUMBER}) {
+      projectItems(first: 10) {
+        nodes {
+          id
+          project { id }
+        }
+      }
+    }
+  }
+}" --jq ".data.repository.issue.projectItems.nodes[] | select(.project.id == \"${PROJECT_ID}\") | .id")
+
+if [ -z "$ITEM_ID" ]; then
+  echo "Issue #${ISSUE_NUMBER} is not on project ${PROJECT_ID} — skipping"
+  exit 0
+fi
+
+echo "Found project item: $ITEM_ID"
+
+# ── Update the status field ───────────────────────────────────────────────────
+
+gh api graphql -f query="
+mutation {
+  updateProjectV2ItemFieldValue(input: {
+    projectId: \"${PROJECT_ID}\"
+    itemId: \"${ITEM_ID}\"
+    fieldId: \"${STATUS_FIELD_ID}\"
+    value: { singleSelectOptionId: \"${STATUS_OPTION_ID}\" }
+  }) {
+    projectV2Item { id }
+  }
+}" > /dev/null
+
+echo "Issue #${ISSUE_NUMBER} status updated to option ${STATUS_OPTION_ID}"

--- a/.github/workflows/begin_release.yml
+++ b/.github/workflows/begin_release.yml
@@ -264,3 +264,54 @@ jobs:
           git tag "$VERSION"
           git push origin "$VERSION"
 
+  # ── Discord notifications ──────────────────────────────────────────────────
+
+  notify-freeze:
+    name: Notify Discord — Freeze Preview
+    needs: [determine, freeze]
+    if: needs.determine.outputs.should_proceed == 'true' && needs.determine.outputs.release_type == 'freeze'
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Post freeze preview to Discord
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DISCORD_CHANGELOG_WEBHOOK_URL: ${{ secrets.DISCORD_CHANGELOG_WEBHOOK_URL }}
+        run: |
+          chmod +x .github/scripts/post-changelog.sh
+          .github/scripts/post-changelog.sh \
+            freeze \
+            "${{ needs.determine.outputs.version }}" \
+            "$DISCORD_CHANGELOG_WEBHOOK_URL" \
+            "${{ github.repository }}"
+
+  notify-release:
+    name: Notify Discord — Release / Hotfix
+    needs: [determine, tag]
+    if: needs.determine.outputs.should_proceed == 'true' && needs.determine.outputs.release_type != 'freeze'
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.determine.outputs.test_ref }}
+
+      - name: Post release changelog to Discord
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DISCORD_CHANGELOG_WEBHOOK_URL: ${{ secrets.DISCORD_CHANGELOG_WEBHOOK_URL }}
+        run: |
+          chmod +x .github/scripts/post-changelog.sh
+          .github/scripts/post-changelog.sh \
+            "${{ needs.determine.outputs.release_type }}" \
+            "${{ needs.determine.outputs.version }}" \
+            "$DISCORD_CHANGELOG_WEBHOOK_URL" \
+            "${{ github.repository }}"
+

--- a/.github/workflows/project-frozen.yml
+++ b/.github/workflows/project-frozen.yml
@@ -1,0 +1,43 @@
+name: Project — Move to Frozen
+
+on:
+  pull_request:
+    types: [closed]
+    branches: ['freeze/**']
+
+permissions:
+  contents: read
+
+jobs:
+  move:
+    name: Move issue to Frozen
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+    environment: production
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Parse issue number from PR title
+        id: parse
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          issue_num=$(echo "$PR_TITLE" | grep -oE '^#[0-9]+' | tr -d '#')
+          if [ -z "$issue_num" ]; then
+            echo "Could not parse issue number from PR title — skipping"
+            echo "skip=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          echo "issue_number=$issue_num" >> $GITHUB_OUTPUT
+          echo "skip=false" >> $GITHUB_OUTPUT
+
+      - name: Move to Frozen
+        if: steps.parse.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          chmod +x .github/scripts/update-project-status.sh
+          .github/scripts/update-project-status.sh \
+            "${{ steps.parse.outputs.issue_number }}" \
+            "250a1c85"

--- a/.github/workflows/project-in-progress.yml
+++ b/.github/workflows/project-in-progress.yml
@@ -1,0 +1,40 @@
+name: Project — Move to In Progress
+
+on:
+  create:
+
+permissions:
+  contents: read
+
+jobs:
+  move:
+    name: Move issue to In Progress
+    runs-on: ubuntu-latest
+    if: github.ref_type == 'branch'
+    environment: production
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Parse issue number from branch name
+        id: parse
+        run: |
+          branch="${{ github.ref_name }}"
+          issue_num=$(echo "$branch" | grep -oE '^[0-9]+' | head -1)
+          if [ -z "$issue_num" ]; then
+            echo "Branch '${branch}' does not start with an issue number — skipping"
+            echo "skip=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          echo "issue_number=$issue_num" >> $GITHUB_OUTPUT
+          echo "skip=false" >> $GITHUB_OUTPUT
+
+      - name: Move to In Progress
+        if: steps.parse.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          chmod +x .github/scripts/update-project-status.sh
+          .github/scripts/update-project-status.sh \
+            "${{ steps.parse.outputs.issue_number }}" \
+            "47fc9ee4"

--- a/.github/workflows/project-release-ready.yml
+++ b/.github/workflows/project-release-ready.yml
@@ -1,0 +1,27 @@
+name: Project — Move to Release Ready
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  contents: read
+
+jobs:
+  move:
+    name: Move issue to Release Ready
+    runs-on: ubuntu-latest
+    if: github.event.label.name == 'release-ready'
+    environment: production
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Move to Release Ready
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          chmod +x .github/scripts/update-project-status.sh
+          .github/scripts/update-project-status.sh \
+            "${{ github.event.issue.number }}" \
+            "df73e18b"

--- a/.github/workflows/project-released.yml
+++ b/.github/workflows/project-released.yml
@@ -1,0 +1,53 @@
+name: Project — Move to Released
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [current-release]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  move:
+    name: Move issue to Released and close
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+    environment: production
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Parse issue number from PR title
+        id: parse
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          issue_num=$(echo "$PR_TITLE" | grep -oE '^#[0-9]+' | tr -d '#')
+          if [ -z "$issue_num" ]; then
+            echo "Could not parse issue number from PR title — skipping"
+            echo "skip=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          echo "issue_number=$issue_num" >> $GITHUB_OUTPUT
+          echo "skip=false" >> $GITHUB_OUTPUT
+
+      - name: Move to Released
+        if: steps.parse.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          chmod +x .github/scripts/update-project-status.sh
+          .github/scripts/update-project-status.sh \
+            "${{ steps.parse.outputs.issue_number }}" \
+            "98236657"
+
+      - name: Close issue
+        if: steps.parse.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue close "${{ steps.parse.outputs.issue_number }}" \
+            --repo "${{ github.repository }}" \
+            --reason completed

--- a/.github/workflows/project-testing.yml
+++ b/.github/workflows/project-testing.yml
@@ -1,0 +1,44 @@
+name: Project — Move to Testing
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  move:
+    name: Move issue to Testing
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+    environment: production
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Parse issue number from PR title
+        id: parse
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          issue_num=$(echo "$PR_TITLE" | grep -oE '^#[0-9]+' | tr -d '#')
+          if [ -z "$issue_num" ]; then
+            echo "Could not parse issue number from PR title — skipping"
+            echo "skip=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          echo "issue_number=$issue_num" >> $GITHUB_OUTPUT
+          echo "skip=false" >> $GITHUB_OUTPUT
+
+      - name: Move to Testing
+        if: steps.parse.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          chmod +x .github/scripts/update-project-status.sh
+          .github/scripts/update-project-status.sh \
+            "${{ steps.parse.outputs.issue_number }}" \
+            "97cbf6d3"

--- a/.github/workflows/project-up-next.yml
+++ b/.github/workflows/project-up-next.yml
@@ -1,0 +1,27 @@
+name: Project — Move to Up Next
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  contents: read
+
+jobs:
+  move:
+    name: Move issue to Up Next
+    runs-on: ubuntu-latest
+    if: github.event.label.name == 'refined'
+    environment: production
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Move to Up Next
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          chmod +x .github/scripts/update-project-status.sh
+          .github/scripts/update-project-status.sh \
+            "${{ github.event.issue.number }}" \
+            "61e4505c"

--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -1,0 +1,29 @@
+name: Validate PR Title
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+    branches: [main]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  validate-title:
+    name: Validate PR title format
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR title matches convention
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          pattern='^#[0-9]+ - (Add|Remove|Update|Revert|Refactor) .+'
+          if echo "$PR_TITLE" | grep -qE "$pattern"; then
+            echo "PR title is valid: $PR_TITLE"
+          else
+            echo "ERROR: PR title does not match required format."
+            echo "Required: #<issue> - <Verb> <summary>"
+            echo "Verbs:    Add, Remove, Update, Revert, Refactor  (no colon, no ALLCAPS)"
+            echo "Got: $PR_TITLE"
+            exit 1
+          fi

--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -6,7 +6,8 @@ on:
     branches: [main]
 
 permissions:
-  pull-requests: read
+  pull-requests: write
+  issues: read
 
 jobs:
   validate-title:
@@ -26,4 +27,42 @@ jobs:
             echo "Verbs:    Add, Remove, Update, Revert, Refactor  (no colon, no ALLCAPS)"
             echo "Got: $PR_TITLE"
             exit 1
+          fi
+
+      - name: Check issue exists and is open
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          issue_num=$(echo "$PR_TITLE" | grep -oE '^#[0-9]+' | tr -d '#')
+          state=$(gh issue view "$issue_num" --repo "${{ github.repository }}" --json state -q '.state')
+          if [ "$state" != "OPEN" ]; then
+            echo "ERROR: Issue #${issue_num} is not open (state: ${state})"
+            echo "PRs must reference an open issue."
+            exit 1
+          fi
+          echo "Issue #${issue_num} is open ✓"
+
+      - name: Link PR to issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          issue_num=$(echo "$PR_TITLE" | grep -oE '^#[0-9]+' | tr -d '#')
+          pr_number="${{ github.event.pull_request.number }}"
+          repo="${{ github.repository }}"
+
+          # Add a cross-reference to the PR body so the issue timeline shows the connection.
+          # We avoid "Closes"/"Fixes" keywords to prevent auto-close on merge to main.
+          current_body=$(gh pr view "$pr_number" --repo "$repo" --json body -q '.body // ""')
+          ref="Tracks #${issue_num}"
+          if ! echo "$current_body" | grep -qF "$ref"; then
+            new_body="${current_body}
+
+<!-- auto-linked -->
+${ref}"
+            gh pr edit "$pr_number" --repo "$repo" --body "$new_body"
+            echo "Linked PR #${pr_number} to issue #${issue_num} ✓"
+          else
+            echo "PR already references issue #${issue_num} ✓"
           fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -209,11 +209,16 @@ npm run db:rollback                                   # revert a migration
 
 ### Branch naming
 ```
-<issue_number> - <issue title>
+<issue_number>-<issue-title-slugified>
 ```
-Example: `105 - improve-fetch-failed-error-messages`
+Example: `105-improve-fetch-failed-error-messages`
 
 Unless explicitly instructed otherwise, every working branch must relate to a specific GitHub issue.
+
+**ALWAYS use `gh issue develop` to create branches** — this links the branch to the issue and makes it appear under the "Development" section of the issue page:
+```bash
+gh issue develop <issue_number> --repo Vulps22/project-encourage-reborn --checkout --base current-release
+```
 
 **ALWAYS branch off `current-release` — NEVER off `main`.** PRs merge into `main`. `current-release` is the production branch; branching off it means every branch starts from a known-good production state. Fixes merged into `current-release` can then flow into any in-flight branch independently, without waiting for unrelated work on `main` to land first.
 


### PR DESCRIPTION
## Summary

- Adds `post-changelog.sh` script that collects merged PRs since the last tag and posts a formatted embed to a Discord `#changelog` channel on release and freeze days
- Adds `notify-freeze` and `notify-release` jobs to `begin_release.yml` to trigger the script automatically
- Adds `validate-pr-title.yml` workflow enforcing the `#N - Verb Summary` PR title format, validating the referenced issue is open, and cross-linking the PR body
- Adds `update-project-status.sh` shared script for moving issues through the GitHub Project board
- Adds six project automation workflows covering the full status lifecycle: Up Next → In Progress → Testing → Release Ready → Frozen → Released
- Updates CLAUDE.md with corrected branch naming convention and `gh issue develop` guidance

## Test plan

- [ ] Trigger `begin_release.yml` via `workflow_dispatch` and confirm Discord embed posts correctly for hotfix path
- [ ] Merge a PR to `main` and confirm linked issue moves to **Testing**
- [ ] Apply `refined` label to an issue and confirm it moves to **Up Next**
- [ ] Apply `release-ready` label to an issue and confirm it moves to **Release Ready**
- [ ] Open a PR with a non-conforming title and confirm `validate-pr-title` blocks it
- [ ] Open a PR referencing a closed issue and confirm `validate-pr-title` blocks it
- [ ] Confirm `DISCORD_CHANGELOG_WEBHOOK_URL` is set as a secret in the `production` environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)