### PR TITLE
#131 - Update report button to add confirmation step

### DIFF
--- a/.github/scripts/post-changelog.sh
+++ b/.github/scripts/post-changelog.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TYPE="$1"         # freeze | release | hotfix
+VERSION="$2"      # e.g. v2026.6.2 or v2026.6.2-H1
+WEBHOOK_URL="$3"
+REPO="$4"
+
+# ── Determine last tag ────────────────────────────────────────────────────────
+
+if [ "$TYPE" = "hotfix" ]; then
+  # Strip -HN suffix: v2026.6.1-H1 → v2026.6.1, v2026.6.1-H2 → v2026.6.1
+  LAST_TAG=$(echo "$VERSION" | sed 's/-H[0-9]*$//')
+else
+  # freeze or release: last non-H release tag, excluding the version just tagged
+  LAST_TAG=$(git tag -l 'v[0-9]*' | grep -v '\-H' | sort -V | grep -v "^${VERSION}$" | tail -1)
+fi
+
+if [ -z "$LAST_TAG" ]; then
+  echo "No previous tag found — collecting all merged PRs"
+  MERGE_RANGE="HEAD"
+else
+  echo "Collecting PRs since $LAST_TAG"
+  MERGE_RANGE="${LAST_TAG}..HEAD"
+fi
+
+# ── Collect PR numbers from git log merge commits ─────────────────────────────
+
+PR_NUMBERS=$(git log "$MERGE_RANGE" --merges --format="%s" \
+  | grep -oE 'pull request #[0-9]+' \
+  | grep -oE '[0-9]+' \
+  | sort -n) || true
+
+if [ -z "$PR_NUMBERS" ]; then
+  echo "No merged PRs found since ${LAST_TAG:-beginning} — skipping Discord notification"
+  exit 0
+fi
+
+# ── Build changelog lines ─────────────────────────────────────────────────────
+
+TITLE_PATTERN='^#[0-9]+ - (Add|Remove|Update|Revert|Refactor) .+'
+CHANGELOG_LINES=""
+
+for PR_NUM in $PR_NUMBERS; do
+  PR_JSON=$(gh pr view "$PR_NUM" --repo "$REPO" --json number,title 2>/dev/null) || {
+    echo "Could not fetch PR #$PR_NUM — skipping"
+    continue
+  }
+  PR_TITLE=$(echo "$PR_JSON" | jq -r '.title')
+
+  if ! echo "$PR_TITLE" | grep -qE "$TITLE_PATTERN"; then
+    echo "Skipping PR #$PR_NUM — title does not match format: $PR_TITLE"
+    continue
+  fi
+
+  # Extract issue number and summary from PR title: "#126 - Update foo bar"
+  ISSUE_NUM=$(echo "$PR_TITLE" | grep -oE '^#[0-9]+' | tr -d '#')
+  SUMMARY=$(echo "$PR_TITLE" | sed 's/^#[0-9]* - //')
+  VERB=$(echo "$SUMMARY" | awk '{print $1}')
+
+  case "$VERB" in
+    Add|Update|Refactor) SYMBOL="+" ;;
+    Remove|Revert)       SYMBOL="-" ;;
+    *)                   SYMBOL="~" ;;
+  esac
+
+  ISSUE_URL="https://github.com/${REPO}/issues/${ISSUE_NUM}"
+  LINE="${SYMBOL} ${SUMMARY} ([#${ISSUE_NUM}](${ISSUE_URL}))"
+
+  if [ -n "$CHANGELOG_LINES" ]; then
+    CHANGELOG_LINES="${CHANGELOG_LINES}\n${LINE}"
+  else
+    CHANGELOG_LINES="$LINE"
+  fi
+done
+
+if [ -z "$CHANGELOG_LINES" ]; then
+  echo "No conforming PRs found — skipping Discord notification"
+  exit 0
+fi
+
+# ── Build embed title, description, and colour per type ──────────────────────
+
+case "$TYPE" in
+  freeze)
+    EMBED_TITLE="Freeze Preview — ${VERSION}"
+    EMBED_COLOR=3447003
+    DESCRIPTION="The following changes are queued for release in **${VERSION}**:"
+    ;;
+  release)
+    EMBED_TITLE="Release ${VERSION}"
+    EMBED_COLOR=3066993
+    DESCRIPTION="The following changes shipped in **${VERSION}**:"
+    ;;
+  hotfix)
+    EMBED_TITLE="Hotfix ${VERSION}"
+    EMBED_COLOR=15158332
+    DESCRIPTION="The following hotfix changes shipped in **${VERSION}**:"
+    ;;
+esac
+
+# ── POST to Discord ───────────────────────────────────────────────────────────
+
+CHANGELOG_BODY=$(printf '%b' "$CHANGELOG_LINES")
+
+PAYLOAD=$(jq -n \
+  --arg title "$EMBED_TITLE" \
+  --arg desc "$DESCRIPTION" \
+  --arg body "$CHANGELOG_BODY" \
+  --argjson color "$EMBED_COLOR" \
+  '{embeds: [{title: $title, description: ($desc + "\n\n" + $body), color: $color}]}')
+
+echo "Posting changelog to Discord..."
+HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+  -H "Content-Type: application/json" \
+  -d "$PAYLOAD" \
+  "$WEBHOOK_URL")
+
+if [ "$HTTP_STATUS" -ge 200 ] && [ "$HTTP_STATUS" -lt 300 ]; then
+  echo "Discord notification sent (HTTP $HTTP_STATUS)"
+else
+  echo "ERROR: Discord webhook returned HTTP $HTTP_STATUS" >&2
+  exit 1
+fi

--- a/.github/scripts/update-project-status.sh
+++ b/.github/scripts/update-project-status.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# update-project-status.sh
+# Usage: update-project-status.sh <issue_number> <status_option_id>
+set -euo pipefail
+
+ISSUE_NUMBER="$1"
+STATUS_OPTION_ID="$2"
+REPO="${GITHUB_REPOSITORY:-Vulps22/project-encourage-reborn}"
+PROJECT_ID="PVT_kwHOACitxM4BbRy3"
+STATUS_FIELD_ID="PVTSSF_lAHOACitxM4BbRy3zhWDZUs"
+
+# ── Find the project item ID for this issue ───────────────────────────────────
+
+OWNER="${REPO%%/*}"
+REPO_NAME="${REPO##*/}"
+
+ITEM_ID=$(gh api graphql -f query="
+{
+  repository(owner: \"${OWNER}\", name: \"${REPO_NAME}\") {
+    issue(number: ${ISSUE_NUMBER}) {
+      projectItems(first: 10) {
+        nodes {
+          id
+          project { id }
+        }
+      }
+    }
+  }
+}" --jq ".data.repository.issue.projectItems.nodes[] | select(.project.id == \"${PROJECT_ID}\") | .id")
+
+if [ -z "$ITEM_ID" ]; then
+  echo "Issue #${ISSUE_NUMBER} is not on project ${PROJECT_ID} — skipping"
+  exit 0
+fi
+
+echo "Found project item: $ITEM_ID"
+
+# ── Update the status field ───────────────────────────────────────────────────
+
+gh api graphql -f query="
+mutation {
+  updateProjectV2ItemFieldValue(input: {
+    projectId: \"${PROJECT_ID}\"
+    itemId: \"${ITEM_ID}\"
+    fieldId: \"${STATUS_FIELD_ID}\"
+    value: { singleSelectOptionId: \"${STATUS_OPTION_ID}\" }
+  }) {
+    projectV2Item { id }
+  }
+}" > /dev/null
+
+echo "Issue #${ISSUE_NUMBER} status updated to option ${STATUS_OPTION_ID}"

--- a/.github/workflows/begin_release.yml
+++ b/.github/workflows/begin_release.yml
@@ -264,3 +264,54 @@ jobs:
           git tag "$VERSION"
           git push origin "$VERSION"
 
+  # ── Discord notifications ──────────────────────────────────────────────────
+
+  notify-freeze:
+    name: Notify Discord — Freeze Preview
+    needs: [determine, freeze]
+    if: needs.determine.outputs.should_proceed == 'true' && needs.determine.outputs.release_type == 'freeze'
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Post freeze preview to Discord
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DISCORD_CHANGELOG_WEBHOOK_URL: ${{ secrets.DISCORD_CHANGELOG_WEBHOOK_URL }}
+        run: |
+          chmod +x .github/scripts/post-changelog.sh
+          .github/scripts/post-changelog.sh \
+            freeze \
+            "${{ needs.determine.outputs.version }}" \
+            "$DISCORD_CHANGELOG_WEBHOOK_URL" \
+            "${{ github.repository }}"
+
+  notify-release:
+    name: Notify Discord — Release / Hotfix
+    needs: [determine, tag]
+    if: needs.determine.outputs.should_proceed == 'true' && needs.determine.outputs.release_type != 'freeze'
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.determine.outputs.test_ref }}
+
+      - name: Post release changelog to Discord
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DISCORD_CHANGELOG_WEBHOOK_URL: ${{ secrets.DISCORD_CHANGELOG_WEBHOOK_URL }}
+        run: |
+          chmod +x .github/scripts/post-changelog.sh
+          .github/scripts/post-changelog.sh \
+            "${{ needs.determine.outputs.release_type }}" \
+            "${{ needs.determine.outputs.version }}" \
+            "$DISCORD_CHANGELOG_WEBHOOK_URL" \
+            "${{ github.repository }}"
+

--- a/.github/workflows/project-frozen.yml
+++ b/.github/workflows/project-frozen.yml
@@ -1,0 +1,43 @@
+name: Project — Move to Frozen
+
+on:
+  pull_request:
+    types: [closed]
+    branches: ['freeze/**']
+
+permissions:
+  contents: read
+
+jobs:
+  move:
+    name: Move issue to Frozen
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+    environment: production
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Parse issue number from PR title
+        id: parse
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          issue_num=$(echo "$PR_TITLE" | grep -oE '^#[0-9]+' | tr -d '#')
+          if [ -z "$issue_num" ]; then
+            echo "Could not parse issue number from PR title — skipping"
+            echo "skip=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          echo "issue_number=$issue_num" >> $GITHUB_OUTPUT
+          echo "skip=false" >> $GITHUB_OUTPUT
+
+      - name: Move to Frozen
+        if: steps.parse.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          chmod +x .github/scripts/update-project-status.sh
+          .github/scripts/update-project-status.sh \
+            "${{ steps.parse.outputs.issue_number }}" \
+            "250a1c85"

--- a/.github/workflows/project-in-progress.yml
+++ b/.github/workflows/project-in-progress.yml
@@ -1,0 +1,40 @@
+name: Project — Move to In Progress
+
+on:
+  create:
+
+permissions:
+  contents: read
+
+jobs:
+  move:
+    name: Move issue to In Progress
+    runs-on: ubuntu-latest
+    if: github.ref_type == 'branch'
+    environment: production
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Parse issue number from branch name
+        id: parse
+        run: |
+          branch="${{ github.ref_name }}"
+          issue_num=$(echo "$branch" | grep -oE '^[0-9]+' | head -1)
+          if [ -z "$issue_num" ]; then
+            echo "Branch '${branch}' does not start with an issue number — skipping"
+            echo "skip=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          echo "issue_number=$issue_num" >> $GITHUB_OUTPUT
+          echo "skip=false" >> $GITHUB_OUTPUT
+
+      - name: Move to In Progress
+        if: steps.parse.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          chmod +x .github/scripts/update-project-status.sh
+          .github/scripts/update-project-status.sh \
+            "${{ steps.parse.outputs.issue_number }}" \
+            "47fc9ee4"

--- a/.github/workflows/project-release-ready.yml
+++ b/.github/workflows/project-release-ready.yml
@@ -1,0 +1,27 @@
+name: Project — Move to Release Ready
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  contents: read
+
+jobs:
+  move:
+    name: Move issue to Release Ready
+    runs-on: ubuntu-latest
+    if: github.event.label.name == 'release-ready'
+    environment: production
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Move to Release Ready
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          chmod +x .github/scripts/update-project-status.sh
+          .github/scripts/update-project-status.sh \
+            "${{ github.event.issue.number }}" \
+            "df73e18b"

--- a/.github/workflows/project-released.yml
+++ b/.github/workflows/project-released.yml
@@ -1,0 +1,53 @@
+name: Project — Move to Released
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [current-release]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  move:
+    name: Move issue to Released and close
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+    environment: production
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Parse issue number from PR title
+        id: parse
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          issue_num=$(echo "$PR_TITLE" | grep -oE '^#[0-9]+' | tr -d '#')
+          if [ -z "$issue_num" ]; then
+            echo "Could not parse issue number from PR title — skipping"
+            echo "skip=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          echo "issue_number=$issue_num" >> $GITHUB_OUTPUT
+          echo "skip=false" >> $GITHUB_OUTPUT
+
+      - name: Move to Released
+        if: steps.parse.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          chmod +x .github/scripts/update-project-status.sh
+          .github/scripts/update-project-status.sh \
+            "${{ steps.parse.outputs.issue_number }}" \
+            "98236657"
+
+      - name: Close issue
+        if: steps.parse.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue close "${{ steps.parse.outputs.issue_number }}" \
+            --repo "${{ github.repository }}" \
+            --reason completed

--- a/.github/workflows/project-testing.yml
+++ b/.github/workflows/project-testing.yml
@@ -1,0 +1,44 @@
+name: Project — Move to Testing
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  move:
+    name: Move issue to Testing
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+    environment: production
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Parse issue number from PR title
+        id: parse
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          issue_num=$(echo "$PR_TITLE" | grep -oE '^#[0-9]+' | tr -d '#')
+          if [ -z "$issue_num" ]; then
+            echo "Could not parse issue number from PR title — skipping"
+            echo "skip=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          echo "issue_number=$issue_num" >> $GITHUB_OUTPUT
+          echo "skip=false" >> $GITHUB_OUTPUT
+
+      - name: Move to Testing
+        if: steps.parse.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          chmod +x .github/scripts/update-project-status.sh
+          .github/scripts/update-project-status.sh \
+            "${{ steps.parse.outputs.issue_number }}" \
+            "97cbf6d3"

--- a/.github/workflows/project-up-next.yml
+++ b/.github/workflows/project-up-next.yml
@@ -1,0 +1,27 @@
+name: Project — Move to Up Next
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  contents: read
+
+jobs:
+  move:
+    name: Move issue to Up Next
+    runs-on: ubuntu-latest
+    if: github.event.label.name == 'refined'
+    environment: production
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Move to Up Next
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          chmod +x .github/scripts/update-project-status.sh
+          .github/scripts/update-project-status.sh \
+            "${{ github.event.issue.number }}" \
+            "61e4505c"

--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -1,0 +1,29 @@
+name: Validate PR Title
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+    branches: [main]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  validate-title:
+    name: Validate PR title format
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR title matches convention
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          pattern='^#[0-9]+ - (Add|Remove|Update|Revert|Refactor) .+'
+          if echo "$PR_TITLE" | grep -qE "$pattern"; then
+            echo "PR title is valid: $PR_TITLE"
+          else
+            echo "ERROR: PR title does not match required format."
+            echo "Required: #<issue> - <Verb> <summary>"
+            echo "Verbs:    Add, Remove, Update, Revert, Refactor  (no colon, no ALLCAPS)"
+            echo "Got: $PR_TITLE"
+            exit 1
+          fi

--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -6,7 +6,8 @@ on:
     branches: [main]
 
 permissions:
-  pull-requests: read
+  pull-requests: write
+  issues: read
 
 jobs:
   validate-title:
@@ -26,4 +27,42 @@ jobs:
             echo "Verbs:    Add, Remove, Update, Revert, Refactor  (no colon, no ALLCAPS)"
             echo "Got: $PR_TITLE"
             exit 1
+          fi
+
+      - name: Check issue exists and is open
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          issue_num=$(echo "$PR_TITLE" | grep -oE '^#[0-9]+' | tr -d '#')
+          state=$(gh issue view "$issue_num" --repo "${{ github.repository }}" --json state -q '.state')
+          if [ "$state" != "OPEN" ]; then
+            echo "ERROR: Issue #${issue_num} is not open (state: ${state})"
+            echo "PRs must reference an open issue."
+            exit 1
+          fi
+          echo "Issue #${issue_num} is open ✓"
+
+      - name: Link PR to issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          issue_num=$(echo "$PR_TITLE" | grep -oE '^#[0-9]+' | tr -d '#')
+          pr_number="${{ github.event.pull_request.number }}"
+          repo="${{ github.repository }}"
+
+          # Add a cross-reference to the PR body so the issue timeline shows the connection.
+          # We avoid "Closes"/"Fixes" keywords to prevent auto-close on merge to main.
+          current_body=$(gh pr view "$pr_number" --repo "$repo" --json body -q '.body // ""')
+          ref="Tracks #${issue_num}"
+          if ! echo "$current_body" | grep -qF "$ref"; then
+            new_body="${current_body}
+
+<!-- auto-linked -->
+${ref}"
+            gh pr edit "$pr_number" --repo "$repo" --body "$new_body"
+            echo "Linked PR #${pr_number} to issue #${issue_num} ✓"
+          else
+            echo "PR already references issue #${issue_num} ✓"
           fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -223,6 +223,8 @@ Example: `105 - improve-fetch-failed-error-messages`
 
 Unless explicitly instructed otherwise, every working branch must relate to a specific GitHub issue.
 
+**ALWAYS branch off `current-release` — NEVER off `main`.** PRs merge into `main`. `current-release` is the production branch; branching off it means every branch starts from a known-good production state. Fixes merged into `current-release` can then flow into any in-flight branch independently, without waiting for unrelated work on `main` to land first.
+
 ### Commit message format
 ```
 #<issue_number> - <message up to 50 characters>
@@ -233,6 +235,17 @@ Example: `#105 - wrap fetch errors with url and reason`
 - Commits must be **single responsibility** — one logical change per commit
 - If a single file contains changes belonging to two different concerns, **cherry-pick the relevant hunks** using `git add -p` rather than committing the file wholesale
 - Never commit incomplete or work-in-progress code that belongs to a different concern — keep each commit self-contained and coherent
+
+### PR title format
+```
+#<issue_number> - Add|Remove|Update|Revert|Refactor <short summary>
+```
+Examples:
+- `#126 - Update all string based messages to new Components V2 views`
+- `#112 - Add vote skip command for inventory`
+- `#99 - Remove deprecated string overload from sendReply`
+
+The changelog script (issue #125) strips the `#<issue> - ` prefix and uses the leading verb for Discord symbol mapping (`Add`/`Update`/`Refactor` → `+`, `Remove`/`Revert` → `-`). A `validate-pr-title.yml` workflow enforces the format — PRs that don't match are blocked. No colon after the verb.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -209,11 +209,16 @@ npm run db:rollback                                   # revert a migration
 
 ### Branch naming
 ```
-<issue_number> - <issue title>
+<issue_number>-<issue-title-slugified>
 ```
-Example: `105 - improve-fetch-failed-error-messages`
+Example: `105-improve-fetch-failed-error-messages`
 
 Unless explicitly instructed otherwise, every working branch must relate to a specific GitHub issue.
+
+**ALWAYS use `gh issue develop` to create branches** — this links the branch to the issue and makes it appear under the "Development" section of the issue page:
+```bash
+gh issue develop <issue_number> --repo Vulps22/project-encourage-reborn --checkout --base current-release
+```
 
 **ALWAYS branch off `current-release` — NEVER off `main`.** PRs merge into `main`. `current-release` is the production branch; branching off it means every branch starts from a known-good production state. Fixes merged into `current-release` can then flow into any in-flight branch independently, without waiting for unrelated work on `main` to land first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,14 +204,6 @@ npm run db:rollback                                   # revert a migration
 
 ---
 
-## Open GitHub Issues
-
-| # | Repo | Summary |
-|---|---|---|
-| [#105](https://github.com/Vulps22/project-encourage-reborn/issues/105) | PE | `fetch failed` error gives no context (URL, service, reason) |
-| [#106](https://github.com/Vulps22/project-encourage-reborn/issues/106) | PE | GitHub Actions test workflows need `NODE_AUTH_TOKEN` for private packages |
-
----
 
 ## Git Conventions
 

--- a/bot-service/src/_handlers/buttons/question/report.ts
+++ b/bot-service/src/_handlers/buttons/question/report.ts
@@ -1,6 +1,6 @@
-import { ActionRowBuilder, ModalBuilder, TextInputBuilder, TextInputStyle } from 'discord.js';
 import { BotButtonInteraction } from '@vulps22/bot-interactions';
 import { Handler } from '../../../utils';
+import { reportConfirmationView } from '../../../views';
 
 const reportButton: Handler<BotButtonInteraction> = {
     name: 'report',
@@ -12,22 +12,7 @@ const reportButton: Handler<BotButtonInteraction> = {
             throw new Error('Invalid question ID when using Button: question_report');
         }
 
-        const modal = new ModalBuilder()
-            .setCustomId(`question_reportModal_id:${questionId}`)
-            .setTitle('Report Question')
-            .addComponents(
-                new ActionRowBuilder<TextInputBuilder>().addComponents(
-                    new TextInputBuilder()
-                        .setCustomId('reason')
-                        .setLabel('Why are you reporting this?')
-                        .setStyle(TextInputStyle.Paragraph)
-                        .setMinLength(10)
-                        .setMaxLength(500)
-                        .setRequired(true)
-                )
-            );
-
-        await interaction.showModal(modal);
+        await interaction.ephemeralReply(reportConfirmationView(questionId));
     }
 };
 

--- a/bot-service/src/_handlers/buttons/question/report_confirmed.ts
+++ b/bot-service/src/_handlers/buttons/question/report_confirmed.ts
@@ -1,0 +1,34 @@
+import { ActionRowBuilder, ModalBuilder, TextInputBuilder, TextInputStyle } from 'discord.js';
+import { BotButtonInteraction } from '@vulps22/bot-interactions';
+import { Handler } from '../../../utils';
+
+const reportButton: Handler<BotButtonInteraction> = {
+    name: 'reportConfirmed',
+    params: { id: 'id' },
+    async execute(interaction: BotButtonInteraction): Promise<void> {
+        const questionId = interaction.params.get(reportButton.params!.id);
+        if (!questionId) {
+            await interaction.ephemeralReply('❌ Invalid question ID');
+            throw new Error('Invalid question ID when using Button: question_report');
+        }
+
+        const modal = new ModalBuilder()
+            .setCustomId(`question_reportModal_id:${questionId}`)
+            .setTitle('Report Question')
+            .addComponents(
+                new ActionRowBuilder<TextInputBuilder>().addComponents(
+                    new TextInputBuilder()
+                        .setCustomId('reason')
+                        .setLabel('Why are you reporting this?')
+                        .setStyle(TextInputStyle.Paragraph)
+                        .setMinLength(10)
+                        .setMaxLength(500)
+                        .setRequired(true)
+                )
+            );
+
+        await interaction.showModal(modal);
+    }
+};
+
+export default reportButton;

--- a/bot-service/src/_handlers/buttons/tests/question/report.test.ts
+++ b/bot-service/src/_handlers/buttons/tests/question/report.test.ts
@@ -1,30 +1,17 @@
-import { ButtonInteraction } from 'discord.js';
 import { BotButtonInteraction } from '@vulps22/bot-interactions';
+import { MessageFlags } from 'discord.js';
 import reportButton from '../../question/report';
 
 describe('reportButton', () => {
-    let mockInteraction: any;
-    let botInteraction: BotButtonInteraction;
+    let mockInteraction: jest.Mocked<BotButtonInteraction>;
 
     beforeEach(() => {
         jest.clearAllMocks();
 
         mockInteraction = {
-            customId: 'question_report_id:42',
-            deferred: false,
-            replied: false,
-            guildId: '987654321',
-            user: { id: '111222333' },
-            reply: jest.fn().mockResolvedValue(undefined),
-            editReply: jest.fn().mockResolvedValue(undefined),
-            showModal: jest.fn().mockResolvedValue(undefined),
-            message: { id: 'msg123' },
-        };
-
-        botInteraction = new BotButtonInteraction(
-            mockInteraction as ButtonInteraction,
-            'exec-123'
-        );
+            params: new Map([['id', '42']]),
+            ephemeralReply: jest.fn().mockResolvedValue(undefined),
+        } as unknown as jest.Mocked<BotButtonInteraction>;
     });
 
     it('should have correct name and params', () => {
@@ -32,22 +19,35 @@ describe('reportButton', () => {
         expect(reportButton.params).toEqual({ id: 'id' });
     });
 
-    it('should show the report reason modal', async () => {
-        await reportButton.execute(botInteraction);
+    it('should show the report confirmation view', async () => {
+        await reportButton.execute(mockInteraction);
 
-        expect(mockInteraction.showModal).toHaveBeenCalledTimes(1);
-        const modal = mockInteraction.showModal.mock.calls[0][0];
-        expect(modal.data.custom_id).toBe('question_reportModal_id:42');
-        expect(modal.data.title).toBe('Report Question');
+        expect(mockInteraction.ephemeralReply).toHaveBeenCalledTimes(1);
+        const message = (mockInteraction.ephemeralReply as jest.Mock).mock.calls[0][0];
+        expect(message.flags).toBe(MessageFlags.IsComponentsV2);
+        expect(message.components).toBeDefined();
+        expect(message.components.length).toBeGreaterThan(0);
     });
 
-    it('should handle missing question ID', async () => {
-        mockInteraction.customId = 'question_report';
-        botInteraction = new BotButtonInteraction(mockInteraction as ButtonInteraction, 'exec-123');
+    it('should include a confirm button targeting the correct question ID', async () => {
+        await reportButton.execute(mockInteraction);
 
-        await expect(reportButton.execute(botInteraction)).rejects.toThrow(
+        const message = (mockInteraction.ephemeralReply as jest.Mock).mock.calls[0][0];
+        const allComponents = message.components.flatMap((c: any) =>
+            c.components ?? [c]
+        );
+        const confirmButton = allComponents.find((c: any) =>
+            c.data?.custom_id === 'question_reportConfirmed_id:42'
+        );
+        expect(confirmButton).toBeDefined();
+    });
+
+    it('should throw and call ephemeralReply when question ID is missing', async () => {
+        (mockInteraction.params as Map<string, string>).clear();
+
+        await expect(reportButton.execute(mockInteraction)).rejects.toThrow(
             'Invalid question ID when using Button: question_report'
         );
-        expect(mockInteraction.showModal).not.toHaveBeenCalled();
+        expect(mockInteraction.ephemeralReply).toHaveBeenCalledWith('❌ Invalid question ID');
     });
 });

--- a/bot-service/src/_handlers/buttons/tests/question/report_confirmed.test.ts
+++ b/bot-service/src/_handlers/buttons/tests/question/report_confirmed.test.ts
@@ -1,0 +1,52 @@
+import { BotButtonInteraction } from '@vulps22/bot-interactions';
+import reportConfirmedButton from '../../question/report_confirmed';
+
+describe('reportConfirmedButton', () => {
+    let mockInteraction: jest.Mocked<BotButtonInteraction>;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+
+        mockInteraction = {
+            params: new Map([['id', '42']]),
+            ephemeralReply: jest.fn().mockResolvedValue(undefined),
+            showModal: jest.fn().mockResolvedValue(undefined),
+        } as unknown as jest.Mocked<BotButtonInteraction>;
+    });
+
+    it('should have correct name and params', () => {
+        expect(reportConfirmedButton.name).toBe('reportConfirmed');
+        expect(reportConfirmedButton.params).toEqual({ id: 'id' });
+    });
+
+    it('should show the report reason modal', async () => {
+        await reportConfirmedButton.execute(mockInteraction);
+
+        expect(mockInteraction.showModal).toHaveBeenCalledTimes(1);
+        const modal = (mockInteraction.showModal as jest.Mock).mock.calls[0][0];
+        expect(modal.data.custom_id).toBe('question_reportModal_id:42');
+        expect(modal.data.title).toBe('Report Question');
+    });
+
+    it('should include a text input with correct settings', async () => {
+        await reportConfirmedButton.execute(mockInteraction);
+
+        const modal = (mockInteraction.showModal as jest.Mock).mock.calls[0][0];
+        const row = modal.components[0];
+        const input = row.components[0];
+        expect(input.data.custom_id).toBe('reason');
+        expect(input.data.min_length).toBe(10);
+        expect(input.data.max_length).toBe(500);
+        expect(input.data.required).toBe(true);
+    });
+
+    it('should throw and call ephemeralReply when question ID is missing', async () => {
+        (mockInteraction.params as Map<string, string>).clear();
+
+        await expect(reportConfirmedButton.execute(mockInteraction)).rejects.toThrow(
+            'Invalid question ID when using Button: question_report'
+        );
+        expect(mockInteraction.ephemeralReply).toHaveBeenCalledWith('❌ Invalid question ID');
+        expect(mockInteraction.showModal).not.toHaveBeenCalled();
+    });
+});

--- a/bot-service/src/config/dev/urls.ts
+++ b/bot-service/src/config/dev/urls.ts
@@ -5,5 +5,5 @@ export const Urls = {
     WIKI: 'http://github.com/Vulps22/truth-or-dare-discord-bot/wiki/',
     ADD_BOT: 'https://discord.com/oauth2/authorize?client_id=1079207025315164331',
     DS_URL: 'http://localhost:3000',
-    MS_URL: 'http://localhost:3001',
+    MS_URL: 'http://localhost:4001',
 } as const;

--- a/bot-service/src/views/index.ts
+++ b/bot-service/src/views/index.ts
@@ -7,3 +7,4 @@ export {rulesView} from './setup/rulesView';
 export {channelSelectView} from './setup/channelSelectView';
 export {setupCompleteView} from './setup/setupCompleteView';
 export {setupFailedView} from './setup/setupFailedView';
+export {reportConfirmationView} from './question_views/reportConfirmation';

--- a/bot-service/src/views/question_views/challengeEmbed.ts
+++ b/bot-service/src/views/question_views/challengeEmbed.ts
@@ -12,7 +12,7 @@ function challengeEmbed(question: Question, challenge: Challenge, vote: Challeng
 
     const reportAccessoryButton = new ButtonBuilder()
         .setCustomId(`question_report_id:${question.id}`)
-        .setLabel('⚠️')
+        .setLabel('⚠️ Report Abuse')
         .setStyle(ButtonStyle.Secondary);
 
     const titleSection = new SectionBuilder()

--- a/bot-service/src/views/question_views/reportConfirmation.ts
+++ b/bot-service/src/views/question_views/reportConfirmation.ts
@@ -1,0 +1,31 @@
+import { UniversalMessage } from "@vulps22/bot-interactions";
+import { ActionRowBuilder, ButtonBuilder, ButtonStyle, MessageFlags, TextDisplayBuilder } from "discord.js";
+
+function reportConfirmationView(questionId: string): UniversalMessage {
+
+    const text = new TextDisplayBuilder()
+        .setContent(
+            `⚠️ By clicking continue you are confirming that you want to report this question for violating the rules.
+            \n Rules can be reviewed by executing the command \`/rules\` in any channel.
+            \n **DO NOT** use the report feature to answer Challenges. These reports are sent to _bot moderators and developers_ for review.
+            \n Abuse of this feature may result in restricted access to bot features or even a ban from using the bot globally.
+            \n\n Are you sure you want to report this question?`
+        );
+
+    const confirmButton = new ButtonBuilder()
+        .setCustomId(`question_reportConfirmed_id:${questionId}`)
+        .setLabel('✅ Confirm Report')
+        .setStyle(ButtonStyle.Danger);
+
+    const actionRow = new ActionRowBuilder<ButtonBuilder>()
+        .addComponents(confirmButton);
+
+    const message: UniversalMessage = {
+        flags: MessageFlags.IsComponentsV2,
+        components: [text, actionRow],
+    }
+
+    return message;
+}
+
+export { reportConfirmationView };


### PR DESCRIPTION
## Summary

- Clicking ⚠️ Report Abuse now shows an ephemeral confirmation view (Components V2) explaining the rules and consequences of abuse, with a **Confirm Report** button
- Clicking **Confirm Report** opens the existing reason modal (moved to new `report_confirmed` handler)
- Adds `reportConfirmationView` in `views/question_views/reportConfirmation.ts` and exports it via the views barrel
- Updates unit tests to reflect the split: `report.test.ts` now verifies the confirmation view, new `report_confirmed.test.ts` covers the modal

## Test plan

- [ ] Click ⚠️ Report Abuse on a challenge embed — confirmation message appears ephemerally
- [ ] Click Confirm Report — reason modal opens
- [ ] Verify missing question ID path still throws and shows error in both handlers
- [ ] All unit tests pass (`jest --testPathPattern="buttons/tests/question/report"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)