### PR TITLE
#153 - Fix vote command skip count case mismatch

### DIFF
--- a/bot-service/src/_handlers/commands/global/vote.ts
+++ b/bot-service/src/_handlers/commands/global/vote.ts
@@ -7,7 +7,7 @@ const vote = new Command('vote', 'Check your skips and vote for the bot on Top.g
     .setAdministrator(false)
     .setExecute(async (interaction: BotCommandInteraction): Promise<void> => {
         const topggUrl = process.env.TOPGG_URL;
-        const inventory = await inventoryService.get(interaction.user.id, 'Skip');
+        const inventory = await inventoryService.get(interaction.user.id, 'skip');
         const skips = inventory?.qty ?? 0;
 
         await interaction.ephemeralReply(

--- a/bot-service/src/_handlers/commands/tests/global/vote.test.ts
+++ b/bot-service/src/_handlers/commands/tests/global/vote.test.ts
@@ -42,33 +42,32 @@ describe('vote command', () => {
         expect(vote.isAdministrator).toBe(false);
     });
 
-    it('should show skip count and top.gg link', async () => {
+    function replyText(): string {
+        const call = (botInteraction.ephemeralReply as jest.Mock).mock.calls[0][0];
+        return call.components[0].toJSON().components[0].content;
+    }
+
+    it('should look up inventory using the lowercase "skip" storable id', async () => {
         (inventoryService.get as jest.Mock).mockResolvedValue({ qty: 3 });
 
         await vote.execute(botInteraction);
 
-        expect(inventoryService.get).toHaveBeenCalledWith('123456789', 'Skip');
-        expect(botInteraction.ephemeralReply).toHaveBeenCalledWith(
-            expect.objectContaining({ flags: expect.any(Number) })
-        );
+        expect(inventoryService.get).toHaveBeenCalledWith('123456789', 'skip');
     });
 
-    it('should show 0 skips when inventory is empty', async () => {
-        (inventoryService.get as jest.Mock).mockResolvedValue(null);
-
-        await vote.execute(botInteraction);
-
-        expect(botInteraction.ephemeralReply).toHaveBeenCalledWith(
-            expect.objectContaining({ flags: expect.any(Number) })
-        );
-    });
-
-    it('should use qty from inventory when present', async () => {
+    it('should display the actual skip count from inventory', async () => {
         (inventoryService.get as jest.Mock).mockResolvedValue({ qty: 5 });
 
         await vote.execute(botInteraction);
 
-        expect(inventoryService.get).toHaveBeenCalledWith('123456789', 'Skip');
-        expect(botInteraction.ephemeralReply).toHaveBeenCalledTimes(1);
+        expect(replyText()).toContain('You have **5** skips remaining');
+    });
+
+    it('should default to 0 skips when inventory is empty', async () => {
+        (inventoryService.get as jest.Mock).mockResolvedValue(null);
+
+        await vote.execute(botInteraction);
+
+        expect(replyText()).toContain('You have **0** skips remaining');
     });
 });


### PR DESCRIPTION
## Summary
- `/vote` command queried inventory with `'Skip'` (capitalized) while every other call site uses lowercase `'skip'`, so it always displayed 0 skips regardless of actual balance
- Fixed the storable id to lowercase `'skip'`
- Added a regression test asserting the correct lowercase lookup and the actual rendered skip count (the prior test asserted the buggy `'Skip'` call directly and never checked rendered content, which is why it didn't catch this)

Closes #153

## Test plan
- [x] `npx jest src/_handlers/commands/tests/global/vote.test.ts` passes
- [x] Verified new test fails against the old `'Skip'` bug and passes with the fix
- [x] Manually confirmed via direct DB query that a user's real skip balance wasn't reflected by `/vote` prior to this fix